### PR TITLE
Add tsc script and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ yarn start
 ```
 
 This runs a Vite powered React + TypeScript app at `http://localhost:3000`.
+
+To verify type safety, run the TypeScript compiler without emitting files:
+
+```bash
+yarn tsc
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "test": "echo 'No tests specified'",
-    "start": "vite"
+    "start": "vite",
+    "tsc": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add `tsc` script to run TypeScript compiler
- document running `yarn tsc` in README

## Testing
- `yarn install`
- `yarn tsc --version`


------
https://chatgpt.com/codex/tasks/task_e_684fa3b61acc832fbb404c8ba54df8e0