### PR TITLE
Allow multiple phone numbers per passenger

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -4,7 +4,7 @@ export const passengers: Passenger[] = [
   {
     id: 'p1',
     name: 'John Doe',
-    phone: '555-0101',
+    phone: ['555-0101'],
     medicaid: 'M123456',
     lastPickup: '123 Main St',
     lastDropoff: '456 Oak Ave',
@@ -12,7 +12,7 @@ export const passengers: Passenger[] = [
   {
     id: 'p2',
     name: 'Jane Smith',
-    phone: '555-0202',
+    phone: ['555-0202'],
     medicaid: 'M654321',
     lastPickup: '789 Pine Rd',
     lastDropoff: '321 Elm St',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export interface Passenger {
   id: string;
   name: string;
-  phone: string;
+  phone: string[];
   medicaid?: string;
   lastPickup?: string;
   lastDropoff?: string;


### PR DESCRIPTION
## Summary
- update `Passenger` type to store an array of phones
- adjust mock data to match new `phone` structure
- let AddTripModal manage multiple phone fields with dynamic add/remove
- populate phone inputs with `<datalist>` suggestions from the selected passenger

## Testing
- `npm run tsc`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68504bf0c4dc832f8f0661dcab28021f