### PR TITLE
Implement passenger address history

### DIFF
--- a/src/components/AddTripModal.tsx
+++ b/src/components/AddTripModal.tsx
@@ -54,10 +54,12 @@ export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles
         phone: passenger.phone[0] || '',
         medicaid: passenger.medicaid ?? '',
         payer: passenger.medicaid ? 'Medicaid' : 'Private',
+        pickup: '',
+        dropoff: '',
       }));
       setPhones(passenger.phone.slice());
     } else {
-      setForm(prev => ({ ...prev, passengerId: '' }));
+      setForm(prev => ({ ...prev, passengerId: '', pickup: '', dropoff: '' }));
       setPhones(['']);
     }
   };
@@ -88,10 +90,17 @@ export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles
         name: passengerName,
         phone: phones.filter(p => p.trim() !== ''),
         medicaid: form.medicaid || undefined,
-        lastPickup: form.pickup,
-        lastDropoff: form.dropoff,
+        addresses: [form.pickup, form.dropoff].filter(a => a.trim() !== ''),
       };
       passengers.push(newPassenger);
+    }
+    const existingPassenger = passengers.find(p => p.id === passengerId);
+    if (existingPassenger) {
+      [form.pickup, form.dropoff].forEach(addr => {
+        if (addr.trim() && !existingPassenger.addresses.includes(addr)) {
+          existingPassenger.addresses.push(addr);
+        }
+      });
     }
 
     const newTrip: Trip = {
@@ -202,6 +211,7 @@ export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles
               <label className="block text-sm mb-1 text-gray-700 dark:text-gray-300">Pickup</label>
               <input
                 type="text"
+                list="address-list"
                 className="w-full border rounded p-2 bg-gray-50 dark:bg-gray-700"
                 value={form.pickup}
                 onChange={e => setForm({ ...form, pickup: e.target.value })}
@@ -211,12 +221,18 @@ export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles
               <label className="block text-sm mb-1 text-gray-700 dark:text-gray-300">Dropoff</label>
               <input
                 type="text"
+                list="address-list"
                 className="w-full border rounded p-2 bg-gray-50 dark:bg-gray-700"
                 value={form.dropoff}
                 onChange={e => setForm({ ...form, dropoff: e.target.value })}
               />
             </div>
           </div>
+          <datalist id="address-list">
+            {(selectedPassenger?.addresses || []).map(addr => (
+              <option key={addr} value={addr} />
+            ))}
+          </datalist>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm mb-1 text-gray-700 dark:text-gray-300">Date</label>

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -6,16 +6,14 @@ export const passengers: Passenger[] = [
     name: 'John Doe',
     phone: ['555-0101'],
     medicaid: 'M123456',
-    lastPickup: '123 Main St',
-    lastDropoff: '456 Oak Ave',
+    addresses: ['123 Main St', '456 Oak Ave'],
   },
   {
     id: 'p2',
     name: 'Jane Smith',
     phone: ['555-0202'],
     medicaid: 'M654321',
-    lastPickup: '789 Pine Rd',
-    lastDropoff: '321 Elm St',
+    addresses: ['789 Pine Rd', '321 Elm St'],
   },
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,8 +3,7 @@ export interface Passenger {
   name: string;
   phone: string[];
   medicaid?: string;
-  lastPickup?: string;
-  lastDropoff?: string;
+  addresses: string[];
 }
 
 export interface Driver {


### PR DESCRIPTION
## Summary
- maintain a list of addresses on passengers
- update mock data to store addresses instead of last pickup/dropoff
- suggest address history in AddTripModal with `<datalist>`
- clear pickup/dropoff fields when switching passengers and append new addresses on submit

## Testing
- `npm test`
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_68504e10cdfc832f991cf5a738ea4487