### PR TITLE
Add passenger persistence and update logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,17 @@ import React, { useState, useEffect } from 'react';
 import {
   trips as initialTrips,
   drivers as initialDrivers,
+  passengers as initialPassengers,
   vehicles,
 } from './data/mockData';
-import { Trip, Driver } from './types';
+import { Trip, Driver, Passenger } from './types';
 import { DispatcherDashboard } from './components/DispatcherDashboard';
 import { DriverManager } from './components/DriverManager';
 
 export const App: React.FC = () => {
   const [trips, setTrips] = useState<Trip[]>(initialTrips);
   const [drivers, setDrivers] = useState<Driver[]>(initialDrivers);
+  const [passengers, setPassengers] = useState<Passenger[]>(initialPassengers);
   const [dark, setDark] = useState(false);
 
   useEffect(() => {
@@ -19,10 +21,11 @@ export const App: React.FC = () => {
     else root.classList.remove('dark');
   }, [dark]);
 
-  // Load persisted trips and drivers on first render
+  // Load persisted trips, drivers and passengers on first render
   useEffect(() => {
     const storedTrips = localStorage.getItem('trips');
     const storedDrivers = localStorage.getItem('drivers');
+    const storedPassengers = localStorage.getItem('passengers');
 
     if (storedTrips) {
       try {
@@ -39,9 +42,17 @@ export const App: React.FC = () => {
         // ignore parse errors and keep defaults
       }
     }
+
+    if (storedPassengers) {
+      try {
+        setPassengers(JSON.parse(storedPassengers));
+      } catch {
+        // ignore parse errors and keep defaults
+      }
+    }
   }, []);
 
-  // Persist trips and drivers whenever they change
+  // Persist trips, drivers and passengers whenever they change
   useEffect(() => {
     localStorage.setItem('trips', JSON.stringify(trips));
   }, [trips]);
@@ -50,12 +61,26 @@ export const App: React.FC = () => {
     localStorage.setItem('drivers', JSON.stringify(drivers));
   }, [drivers]);
 
+  useEffect(() => {
+    localStorage.setItem('passengers', JSON.stringify(passengers));
+  }, [passengers]);
+
   const addTrip = (trip: Trip) => {
     setTrips(prev => [...prev, trip]);
   };
 
   const addDriver = (driver: Driver) => {
     setDrivers(prev => [...prev, driver]);
+  };
+
+  const addPassenger = (passenger: Passenger) => {
+    setPassengers(prev => [...prev, passenger]);
+  };
+
+  const updatePassenger = (passenger: Passenger) => {
+    setPassengers(prev =>
+      prev.map(p => (p.id === passenger.id ? passenger : p))
+    );
   };
 
   return (
@@ -69,7 +94,15 @@ export const App: React.FC = () => {
           {dark ? 'Light' : 'Dark'} Mode
         </button>
       </div>
-      <DispatcherDashboard trips={trips} drivers={drivers} vehicles={vehicles} addTrip={addTrip} />
+      <DispatcherDashboard
+        trips={trips}
+        drivers={drivers}
+        vehicles={vehicles}
+        passengers={passengers}
+        addTrip={addTrip}
+        addPassenger={addPassenger}
+        updatePassenger={updatePassenger}
+      />
       <DriverManager drivers={drivers} addDriver={addDriver} />
     </div>
   );

--- a/src/__tests__/AddTripModal.test.tsx
+++ b/src/__tests__/AddTripModal.test.tsx
@@ -10,7 +10,10 @@ describe('AddTripModal', () => {
         onClose={() => {}}
         drivers={[]}
         vehicles={[]}
+        passengers={[]}
         addTrip={() => {}}
+        addPassenger={() => {}}
+        updatePassenger={() => {}}
       />
     );
     expect(screen.getByText(/Medicaid ID/i)).toBeInTheDocument();

--- a/src/components/AddTripModal.tsx
+++ b/src/components/AddTripModal.tsx
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import { Passenger, Driver, Vehicle, Trip } from '../types';
-import { passengers } from '../data/mockData';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   drivers: Driver[];
   vehicles: Vehicle[];
+  passengers: Passenger[];
   addTrip: (trip: Trip) => void;
+  addPassenger: (p: Passenger) => void;
+  updatePassenger: (p: Passenger) => void;
 }
 
 const defaultTrip: Omit<Trip, 'id' | 'invoice' | 'status'> = {
@@ -24,7 +26,16 @@ const defaultTrip: Omit<Trip, 'id' | 'invoice' | 'status'> = {
   medicaid: '',
 };
 
-export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles, addTrip }) => {
+export const AddTripModal: React.FC<Props> = ({
+  open,
+  onClose,
+  drivers,
+  vehicles,
+  passengers,
+  addTrip,
+  addPassenger,
+  updatePassenger,
+}) => {
   const [form, setForm] = useState(defaultTrip);
   const [invoice, setInvoice] = useState('');
   const [passengerName, setPassengerName] = useState('');
@@ -91,7 +102,28 @@ export const AddTripModal: React.FC<Props> = ({ open, onClose, drivers, vehicles
         lastPickup: form.pickup,
         lastDropoff: form.dropoff,
       };
-      passengers.push(newPassenger);
+      addPassenger(newPassenger);
+    } else {
+      const existing = passengers.find(p => p.id === passengerId);
+      if (existing) {
+        const trimmed = phones.filter(p => p.trim() !== '');
+        const phoneSet = Array.from(new Set([...existing.phone, ...trimmed]));
+        const pickupChanged = form.pickup && form.pickup !== existing.lastPickup;
+        const dropoffChanged =
+          form.dropoff && form.dropoff !== existing.lastDropoff;
+        if (
+          phoneSet.length !== existing.phone.length ||
+          pickupChanged ||
+          dropoffChanged
+        ) {
+          updatePassenger({
+            ...existing,
+            phone: phoneSet,
+            lastPickup: pickupChanged ? form.pickup : existing.lastPickup,
+            lastDropoff: dropoffChanged ? form.dropoff : existing.lastDropoff,
+          });
+        }
+      }
     }
 
     const newTrip: Trip = {

--- a/src/components/DispatcherDashboard.tsx
+++ b/src/components/DispatcherDashboard.tsx
@@ -1,16 +1,27 @@
 import React, { useState } from 'react';
-import { Trip, Driver, Vehicle } from '../types';
-import { passengers } from '../data/mockData';
+import { Trip, Driver, Vehicle, Passenger } from '../types';
+
 import { AddTripModal } from './AddTripModal';
 
 interface Props {
   trips: Trip[];
   drivers: Driver[];
   vehicles: Vehicle[];
+  passengers: Passenger[];
   addTrip: (trip: Trip) => void;
+  addPassenger: (p: Passenger) => void;
+  updatePassenger: (p: Passenger) => void;
 }
 
-export const DispatcherDashboard: React.FC<Props> = ({ trips, drivers, vehicles, addTrip }) => {
+export const DispatcherDashboard: React.FC<Props> = ({
+  trips,
+  drivers,
+  vehicles,
+  passengers,
+  addTrip,
+  addPassenger,
+  updatePassenger,
+}) => {
   const [filterDriver, setFilterDriver] = useState('');
   const [filterDate, setFilterDate] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
@@ -84,7 +95,10 @@ export const DispatcherDashboard: React.FC<Props> = ({ trips, drivers, vehicles,
         onClose={() => setModalOpen(false)}
         drivers={drivers}
         vehicles={vehicles}
+        passengers={passengers}
         addTrip={addTrip}
+        addPassenger={addPassenger}
+        updatePassenger={updatePassenger}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- manage passengers in `App.tsx` with add/update helpers
- persist passengers to `localStorage`
- allow `AddTripModal` to create/update passengers
- pass passenger data and helpers through `DispatcherDashboard`
- adjust unit tests for updated props

## Testing
- `npm run tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504e166518832fa8c42bab7e10d673