### PR TITLE
Revert autocomplete list positioning

### DIFF
--- a/src/components/AutocompleteInput.tsx
+++ b/src/components/AutocompleteInput.tsx
@@ -40,7 +40,7 @@ export const AutocompleteInput: React.FC<Props> = ({
       {open && filtered.length > 0 && (
         <ul
           data-testid="autocomplete-options"
-          className="absolute z-10 mt-1 left-0 top-full w-full max-h-40 overflow-auto border bg-white dark:bg-gray-800 rounded shadow"
+          className="absolute z-10 mt-1 w-full max-h-40 overflow-auto border bg-white dark:bg-gray-800 rounded shadow"
         >
           {filtered.map(opt => (
             <li key={opt}>


### PR DESCRIPTION
## Summary
- restore original dropdown styles without explicit positioning

## Testing
- `npm run tsc`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68505a830c98832f912184ec5353594a