### PR TITLE
Add sidebar navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,12 +8,16 @@ import {
 import { Trip, Driver, Passenger } from './types';
 import { DispatcherDashboard } from './components/DispatcherDashboard';
 import { DriverManager } from './components/DriverManager';
+import { Sidebar, ViewOption } from './components/Sidebar';
+import { PassengerList } from './components/PassengerList';
+import { VehicleList } from './components/VehicleList';
 
 export const App: React.FC = () => {
   const [trips, setTrips] = useState<Trip[]>(initialTrips);
   const [drivers, setDrivers] = useState<Driver[]>(initialDrivers);
   const [passengers, setPassengers] = useState<Passenger[]>(initialPassengers);
   const [dark, setDark] = useState(false);
+  const [view, setView] = useState<ViewOption>('dashboard');
 
   useEffect(() => {
     const root = document.documentElement;
@@ -84,26 +88,37 @@ export const App: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4 space-y-6">
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Dispatcher Dashboard</h1>
-        <button
-          className="px-2 py-1 text-sm rounded border bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200"
-          onClick={() => setDark(!dark)}
-        >
-          {dark ? 'Light' : 'Dark'} Mode
-        </button>
-      </div>
-      <DispatcherDashboard
-        trips={trips}
-        drivers={drivers}
-        vehicles={vehicles}
-        passengers={passengers}
-        addTrip={addTrip}
-        addPassenger={addPassenger}
-        updatePassenger={updatePassenger}
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex">
+      <Sidebar
+        current={view}
+        onSelect={setView}
+        dark={dark}
+        toggleDark={() => setDark(!dark)}
       />
-      <DriverManager drivers={drivers} addDriver={addDriver} />
+      <main className="flex-1 p-4 space-y-6">
+        <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Dispatcher Dashboard</h1>
+        {(view === 'dashboard' || view === 'trips') && (
+          <DispatcherDashboard
+            trips={trips}
+            drivers={drivers}
+            vehicles={vehicles}
+            passengers={passengers}
+            addTrip={addTrip}
+            addPassenger={addPassenger}
+            updatePassenger={updatePassenger}
+          />
+        )}
+        {(view === 'dashboard' || view === 'drivers') && (
+          <DriverManager drivers={drivers} addDriver={addDriver} />
+        )}
+        {view === 'passengers' && <PassengerList passengers={passengers} />}
+        {view === 'vehicles' && <VehicleList vehicles={vehicles} />}
+        {view === 'settings' && (
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow text-gray-700 dark:text-gray-200">
+            Use the sidebar to toggle dark mode.
+          </div>
+        )}
+      </main>
     </div>
   );
 };

--- a/src/components/PassengerList.tsx
+++ b/src/components/PassengerList.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Passenger } from '../types';
+
+interface Props {
+  passengers: Passenger[];
+}
+
+export const PassengerList: React.FC<Props> = ({ passengers }) => (
+  <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Passengers</h2>
+    <ul className="space-y-1">
+      {passengers.map(p => (
+        <li key={p.id} className="text-gray-700 dark:text-gray-200">
+          {p.name} - {p.phone.join(', ')}
+        </li>
+      ))}
+    </ul>
+  </div>
+);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export type ViewOption =
+  | 'dashboard'
+  | 'trips'
+  | 'drivers'
+  | 'passengers'
+  | 'vehicles'
+  | 'settings';
+
+interface Props {
+  current: ViewOption;
+  onSelect: (view: ViewOption) => void;
+  dark: boolean;
+  toggleDark: () => void;
+}
+
+export const Sidebar: React.FC<Props> = ({ current, onSelect, dark, toggleDark }) => {
+  const itemClass = (id: ViewOption) =>
+    `block w-full text-left px-2 py-1 rounded ${current === id ? 'bg-blue-600 text-white' : 'text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700'}`;
+
+  return (
+    <aside className="w-48 flex-shrink-0 bg-white dark:bg-gray-800 p-4 space-y-2">
+      <button className={itemClass('dashboard')} onClick={() => onSelect('dashboard')}>
+        Dashboard
+      </button>
+      <button className={itemClass('trips')} onClick={() => onSelect('trips')}>
+        Trips
+      </button>
+      <button className={itemClass('drivers')} onClick={() => onSelect('drivers')}>
+        Drivers
+      </button>
+      <button className={itemClass('passengers')} onClick={() => onSelect('passengers')}>
+        Passengers
+      </button>
+      <button className={itemClass('vehicles')} onClick={() => onSelect('vehicles')}>
+        Vehicles
+      </button>
+      <button className={itemClass('settings')} onClick={() => onSelect('settings')}>
+        Settings
+      </button>
+      <hr className="my-2 border-gray-300 dark:border-gray-700" />
+      <button
+        className="w-full px-2 py-1 text-left rounded border bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+        onClick={toggleDark}
+      >
+        {dark ? 'Light' : 'Dark'} Mode
+      </button>
+    </aside>
+  );
+};

--- a/src/components/VehicleList.tsx
+++ b/src/components/VehicleList.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Vehicle } from '../types';
+
+interface Props {
+  vehicles: Vehicle[];
+}
+
+export const VehicleList: React.FC<Props> = ({ vehicles }) => (
+  <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Vehicles</h2>
+    <ul className="space-y-1">
+      {vehicles.map(v => (
+        <li key={v.id} className="text-gray-700 dark:text-gray-200">
+          {v.label}
+        </li>
+      ))}
+    </ul>
+  </div>
+);


### PR DESCRIPTION
## Summary
- add Sidebar with navigation items
- show passengers and vehicles lists
- integrate sidebar in the main App

## Testing
- `npm test`
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_6850610cf564832fa5b52975d4802326