### PR TITLE
Add editable driver table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,10 @@ export const App: React.FC = () => {
     setDrivers(prev => [...prev, driver]);
   };
 
+  const updateDriver = (driver: Driver) => {
+    setDrivers(prev => prev.map(d => (d.id === driver.id ? driver : d)));
+  };
+
   const addPassenger = (passenger: Passenger) => {
     setPassengers(prev => [...prev, passenger]);
   };
@@ -109,7 +113,11 @@ export const App: React.FC = () => {
           />
         )}
         {(view === 'dashboard' || view === 'drivers') && (
-          <DriverManager drivers={drivers} addDriver={addDriver} />
+          <DriverManager
+            drivers={drivers}
+            addDriver={addDriver}
+            updateDriver={updateDriver}
+          />
         )}
         {view === 'passengers' && <PassengerList passengers={passengers} />}
         {view === 'vehicles' && <VehicleList vehicles={vehicles} />}

--- a/src/components/DriverManager.tsx
+++ b/src/components/DriverManager.tsx
@@ -4,58 +4,143 @@ import { Driver } from '../types';
 interface Props {
   drivers: Driver[];
   addDriver: (driver: Driver) => void;
+  updateDriver: (driver: Driver) => void;
 }
 
-export const DriverManager: React.FC<Props> = ({ drivers, addDriver }) => {
-  const [name, setName] = useState('');
-  const [phone, setPhone] = useState('');
-  const [email, setEmail] = useState('');
+export const DriverManager: React.FC<Props> = ({ drivers, addDriver, updateDriver }) => {
+  const [newDriver, setNewDriver] = useState<Driver | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editData, setEditData] = useState<Driver | null>(null);
 
-  const handleAdd = () => {
-    if (!name || !phone || !email) return;
-    addDriver({ id: `d-${Date.now()}`, name, phone, email });
-    setName('');
-    setPhone('');
-    setEmail('');
+  const handleAddRow = () => {
+    setNewDriver({
+      id: '',
+      name: '',
+      phone: '',
+      email: '',
+      license: '',
+      licenseExpiration: '',
+    });
   };
+
+  const handleSaveNew = () => {
+    if (!newDriver) return;
+    if (
+      !newDriver.name ||
+      !newDriver.phone ||
+      !newDriver.email ||
+      !newDriver.license ||
+      !newDriver.licenseExpiration
+    )
+      return;
+    addDriver({ ...newDriver, id: `d-${Date.now()}` });
+    setNewDriver(null);
+  };
+
+  const handleCancelNew = () => setNewDriver(null);
+
+  const handleEdit = (driver: Driver) => {
+    setEditingId(driver.id);
+    setEditData({ ...driver });
+  };
+
+  const handleSaveEdit = () => {
+    if (!editData) return;
+    updateDriver(editData);
+    setEditingId(null);
+    setEditData(null);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditData(null);
+  };
+
+  const renderRowInputs = (data: Driver, onChange: (d: Driver) => void, save: () => void, cancel: () => void) => (
+    <tr>
+      <td className="p-2">
+        <input
+          className="border rounded p-1 w-full bg-gray-50 dark:bg-gray-700"
+          value={data.name}
+          onChange={e => onChange({ ...data, name: e.target.value })}
+        />
+      </td>
+      <td className="p-2">
+        <input
+          className="border rounded p-1 w-full bg-gray-50 dark:bg-gray-700"
+          value={data.phone}
+          onChange={e => onChange({ ...data, phone: e.target.value })}
+        />
+      </td>
+      <td className="p-2">
+        <input
+          className="border rounded p-1 w-full bg-gray-50 dark:bg-gray-700"
+          value={data.email}
+          onChange={e => onChange({ ...data, email: e.target.value })}
+        />
+      </td>
+      <td className="p-2">
+        <input
+          className="border rounded p-1 w-full bg-gray-50 dark:bg-gray-700"
+          value={data.license}
+          onChange={e => onChange({ ...data, license: e.target.value })}
+        />
+      </td>
+      <td className="p-2">
+        <input
+          type="date"
+          className="border rounded p-1 w-full bg-gray-50 dark:bg-gray-700"
+          value={data.licenseExpiration}
+          onChange={e => onChange({ ...data, licenseExpiration: e.target.value })}
+        />
+      </td>
+      <td className="p-2 flex space-x-1">
+        <button className="text-green-600" onClick={save} title="Save">✔️</button>
+        <button className="text-red-600" onClick={cancel} title="Cancel">✖️</button>
+      </td>
+    </tr>
+  );
 
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
       <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Drivers</h2>
-      <ul className="space-y-1 mb-4">
-        {drivers.map(d => (
-          <li key={d.id} className="text-gray-700 dark:text-gray-200">{d.name} - {d.phone}</li>
-        ))}
-      </ul>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
-        <input
-          type="text"
-          className="border rounded p-2 bg-gray-50 dark:bg-gray-700"
-          placeholder="Name"
-          value={name}
-          onChange={e => setName(e.target.value)}
-        />
-        <input
-          type="text"
-          className="border rounded p-2 bg-gray-50 dark:bg-gray-700"
-          placeholder="Phone"
-          value={phone}
-          onChange={e => setPhone(e.target.value)}
-        />
-        <input
-          type="email"
-          className="border rounded p-2 bg-gray-50 dark:bg-gray-700"
-          placeholder="Email"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-        />
-      </div>
-      <button
-        className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
-        onClick={handleAdd}
-      >
+      <button className="mb-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={handleAddRow}>
         Add Driver
       </button>
+      <table className="min-w-full table-auto">
+        <thead>
+          <tr className="text-left text-gray-700 dark:text-gray-200">
+            <th className="p-2">Name</th>
+            <th className="p-2">Phone</th>
+            <th className="p-2">Email</th>
+            <th className="p-2">License</th>
+            <th className="p-2">Expiration</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {newDriver &&
+            renderRowInputs(newDriver, setNewDriver, handleSaveNew, handleCancelNew)}
+          {drivers.map(d =>
+            editingId === d.id && editData ? (
+              renderRowInputs(editData, setEditData, handleSaveEdit, handleCancelEdit)
+            ) : (
+              <tr key={d.id} className="text-gray-700 dark:text-gray-200">
+                <td className="p-2">{d.name}</td>
+                <td className="p-2">{d.phone}</td>
+                <td className="p-2">{d.email}</td>
+                <td className="p-2">{d.license}</td>
+                <td className="p-2">{d.licenseExpiration}</td>
+                <td className="p-2">
+                  <button className="text-blue-600" onClick={() => handleEdit(d)}>
+                    Edit
+                  </button>
+                </td>
+              </tr>
+            )
+          )}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -18,8 +18,22 @@ export const passengers: Passenger[] = [
 ];
 
 export const drivers: Driver[] = [
-  { id: 'd1', name: 'Alice Johnson', phone: '555-1111', email: 'alice@example.com' },
-  { id: 'd2', name: 'Bob Lee', phone: '555-2222', email: 'bob@example.com' },
+  {
+    id: 'd1',
+    name: 'Alice Johnson',
+    phone: '555-1111',
+    email: 'alice@example.com',
+    license: 'A123456',
+    licenseExpiration: '2025-12-31',
+  },
+  {
+    id: 'd2',
+    name: 'Bob Lee',
+    phone: '555-2222',
+    email: 'bob@example.com',
+    license: 'B654321',
+    licenseExpiration: '2024-08-15',
+  },
 ];
 
 export const vehicles: Vehicle[] = [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,8 @@ export interface Driver {
   name: string;
   phone: string;
   email: string;
+  license: string;
+  licenseExpiration: string;
 }
 
 export interface Vehicle {


### PR DESCRIPTION
## Summary
- track license info for drivers
- persist license data in mock database
- support editing drivers inline or adding new ones

## Testing
- `npm run tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685066e7e6e0832fabf038318e6b7b16