### PR TITLE
Fix driver table edit row order and icon

### DIFF
--- a/src/components/DriverManager.tsx
+++ b/src/components/DriverManager.tsx
@@ -119,8 +119,6 @@ export const DriverManager: React.FC<Props> = ({ drivers, addDriver, updateDrive
           </tr>
         </thead>
         <tbody>
-          {newDriver &&
-            renderRowInputs(newDriver, setNewDriver, handleSaveNew, handleCancelNew)}
           {drivers.map(d =>
             editingId === d.id && editData ? (
               renderRowInputs(editData, setEditData, handleSaveEdit, handleCancelEdit)
@@ -132,13 +130,15 @@ export const DriverManager: React.FC<Props> = ({ drivers, addDriver, updateDrive
                 <td className="p-2">{d.license}</td>
                 <td className="p-2">{d.licenseExpiration}</td>
                 <td className="p-2">
-                  <button className="text-blue-600" onClick={() => handleEdit(d)}>
-                    Edit
+                  <button className="text-blue-600" onClick={() => handleEdit(d)} title="Edit">
+                    ✏️
                   </button>
                 </td>
               </tr>
             )
           )}
+          {newDriver &&
+            renderRowInputs(newDriver, setNewDriver, handleSaveNew, handleCancelNew)}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- show newly added driver row at the bottom instead of the top
- use a pencil icon instead of the `Edit` text in each driver row

## Testing
- `npm run tsc`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68506a295b0c832fbdce11bc446fe4ce