### PR TITLE
Fix driver table width

### DIFF
--- a/src/components/DriverManager.tsx
+++ b/src/components/DriverManager.tsx
@@ -102,7 +102,7 @@ export const DriverManager: React.FC<Props> = ({ drivers, addDriver, updateDrive
   );
 
   return (
-    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow overflow-x-auto">
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow overflow-x-auto w-1/3">
       <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Drivers</h2>
       <button className="mb-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={handleAddRow}>
         Add Driver


### PR DESCRIPTION
## Summary
- keep driver table container at 1/3 width

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68508365ef58832f818a3d22f1c10072