### PR TITLE
Make driver manager full width

### DIFF
--- a/src/components/DriverManager.tsx
+++ b/src/components/DriverManager.tsx
@@ -102,7 +102,7 @@ export const DriverManager: React.FC<Props> = ({ drivers, addDriver, updateDrive
   );
 
   return (
-    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow overflow-x-auto w-1/3">
+    <div className="bg-white dark:bg-gray-800 p-4 rounded shadow overflow-x-auto w-full">
       <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Drivers</h2>
       <button className="mb-2 px-4 py-2 bg-blue-600 text-white rounded" onClick={handleAddRow}>
         Add Driver


### PR DESCRIPTION
## Summary
- make the DriverManager component use the full available width

## Testing
- `npm run tsc`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68508cd88d2c832fa7e5d9d110e7e167