### PR TITLE
Add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Dispatch-System
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm start
+```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- add `start` script to package.json
- document how to launch dev server in README

## Testing
- `npm install`
- `npm run build`
- `npm start -- --help`

------
https://chatgpt.com/codex/tasks/task_e_6852e4d7b86c832fa5954fa7984534df