### PR TITLE
Remove ID display from UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,15 @@ export default function App() {
       <aside className="trip-queue">
         <div className="panel-header" id="trip-panel-header">
           <h2>
-            {filterType === 'none' ? 'Trip Manifest' : `Filtered: ${filterId}`}
+            {filterType === 'none'
+              ? 'Trip Manifest'
+              : filterType === 'trip'
+                ? `Trip for ${
+                    tripsToDisplay.find(t => t.id === filterId)?.passenger || filterId
+                  }`
+                : filterType === 'driver'
+                  ? `Driver: ${MOCK_DRIVERS[filterId || '']?.name || filterId}`
+                  : `Passenger: ${filterId}`}
           </h2>
           {filterType !== 'none' && (
             <button
@@ -148,7 +156,6 @@ export default function App() {
                     >
                       {trip.passenger}
                     </h3>
-                    <span style={{ flexShrink: 0, marginLeft: '10px' }}>{trip.id.toUpperCase()}</span>
                   </div>
                   <div className="trip-locations">
                     <p>


### PR DESCRIPTION
## Summary
- drop trip ID from trip cards
- show friendly labels in the Trip Manifest header when filtered

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852f5cd34e4832f9a2d056960ba2fb1