### PR TITLE
Implement double-click filtering in trip list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [filterType, setFilterType] = useState<FilterType>('none');
   const [filterId, setFilterId] = useState<string | null>(null);
+  const [detailedTrip, setDetailedTrip] = useState<Trip | null>(null);
 
   const dateKey = getDateKey(selectedDate);
   const allTripsForDay = MOCK_SCHEDULE[dateKey] || [];
@@ -67,6 +68,7 @@ export default function App() {
   useEffect(() => {
     setFilterType('none');
     setFilterId(null);
+    setDetailedTrip(null);
   }, [selectedDate]);
 
   return (
@@ -111,6 +113,7 @@ export default function App() {
               onClick={() => {
                 setFilterType('none');
                 setFilterId(null);
+                setDetailedTrip(null);
               }}
             >
               <i className="fas fa-xmark" /> Show All
@@ -118,6 +121,35 @@ export default function App() {
           )}
         </div>
         <div className="trip-list" id="trip-list-container">
+          {detailedTrip && (
+            <div className="trip-details">
+              <div className="details-header">
+                <h3>{detailedTrip.passenger}</h3>
+                <button
+                  className="close-details-btn"
+                  onClick={() => setDetailedTrip(null)}
+                >
+                  <i className="fas fa-xmark" />
+                </button>
+              </div>
+              <p>
+                <strong>Trip ID:</strong> {detailedTrip.id.toUpperCase()}
+              </p>
+              <p>
+                <strong>From:</strong> {detailedTrip.from}
+              </p>
+              <p>
+                <strong>To:</strong> {detailedTrip.to}
+              </p>
+              <p>
+                <strong>Pickup:</strong> {detailedTrip.time}
+              </p>
+              <p>
+                <strong>Driver:</strong>{' '}
+                {MOCK_DRIVERS[detailedTrip.driverId].name}
+              </p>
+            </div>
+          )}
           {tripsToDisplay.length === 0 && (
             <p style={{ textAlign: 'center', color: 'var(--text-secondary)', padding: '20px' }}>
               No trips found.
@@ -136,6 +168,12 @@ export default function App() {
                   onClick={() => {
                     setFilterType('trip');
                     setFilterId(trip.id);
+                    setDetailedTrip(null);
+                  }}
+                  onDoubleClick={() => {
+                    setFilterType('passenger');
+                    setFilterId(trip.passenger);
+                    setDetailedTrip(null);
                   }}
                 >
                   <div className="trip-header">
@@ -144,6 +182,11 @@ export default function App() {
                         e.stopPropagation();
                         setFilterType('passenger');
                         setFilterId(trip.passenger);
+                        setDetailedTrip(null);
+                      }}
+                      onDoubleClick={e => {
+                        e.stopPropagation();
+                        setDetailedTrip(trip);
                       }}
                     >
                       {trip.passenger}
@@ -184,6 +227,7 @@ export default function App() {
                 onClick={() => {
                   setFilterType('driver');
                   setFilterId(driver.id);
+                  setDetailedTrip(null);
                 }}
               >
                 <div className="driver-profile">

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,32 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
   color: var(--text-secondary);
 }
 
+.trip-details {
+  background: rgba(26, 29, 45, 0.8);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 10px;
+}
+
+.trip-details .details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.close-details-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.close-details-btn:hover {
+  color: var(--accent-teal);
+}
+
 .driver-card { flex-shrink: 0; width: 220px; background-color: var(--bg-deep-charcoal); padding: 15px; display: flex; flex-direction: column; }
 .driver-profile { display: flex; align-items: center; gap: 12px; }
 .driver-profile img { width: 40px; height: 40px; border-radius: 50%; }


### PR DESCRIPTION
## Summary
- allow double-click on a trip card to filter by passenger
- show passenger trip details using sidebar instead of popup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852f71e6fa0832fa912a6986bd17377