### PR TITLE
Add vertical status bar to trips

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -82,10 +82,40 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
 
 .trip-card {
   background: rgba(26, 29, 45, 0.6);
-  padding: 8px;
+  padding: 8px 8px 8px 12px;
   margin-bottom: 8px;
   display: flex;
   flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.trip-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background-color: var(--status-progress);
+  border-radius: 8px 0 0 8px;
+}
+
+.trip-card[data-status='pending']::before {
+  background-color: var(--status-urgent);
+}
+
+.trip-card[data-status='en-route']::before,
+.trip-card[data-status='in-transit']::before {
+  background-color: var(--status-progress);
+}
+
+.trip-card[data-status='at-pickup']::before {
+  background-color: var(--status-arrived);
+}
+
+.trip-card[data-status='complete']::before {
+  background-color: var(--status-complete);
 }
 .trip-header h3 {
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- show colored status bar on trip cards

## Testing
- `npm run build`
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685305aa1a58832f8d19de70f6f0eb62