### PR TITLE
Refactor utility functions into separate files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import './index.css';
 import { MOCK_DRIVERS, MOCK_SCHEDULE, Trip, Driver } from './mockData';
-import { getDateKey } from "./utils";
+import { getDateKey } from "./utils/dateUtils";
 import {
   CommandBar,
   TripQueue,

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateForDisplay } from '../utils';
+import { formatDateForDisplay } from '../utils/dateUtils';
 
 interface CommandBarProps {
   selectedDate: Date;

--- a/src/components/DriverCard.tsx
+++ b/src/components/DriverCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Driver } from '../mockData';
-import { DriverStatus } from '../utils';
+import { DriverStatus } from '../utils/driverUtils';
 
 interface DriverCardProps {
   driver: Driver;

--- a/src/components/DriverRoster.tsx
+++ b/src/components/DriverRoster.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Driver, Trip } from '../mockData';
 import DriverCard from './DriverCard';
-import { getDriverStatus } from '../utils';
+import { getDriverStatus } from '../utils/driverUtils';
 
 
 interface DriverRosterProps {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,9 @@
+export function getDateKey(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+export function formatDateForDisplay(date: Date): string {
+  return new Date().toDateString() === date.toDateString()
+    ? 'Today'
+    : date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}

--- a/src/utils/driverUtils.ts
+++ b/src/utils/driverUtils.ts
@@ -1,14 +1,4 @@
-import { Trip } from './mockData';
-
-export function getDateKey(date: Date) {
-  return date.toISOString().split('T')[0];
-}
-
-export function formatDateForDisplay(date: Date) {
-  return new Date().toDateString() === date.toDateString()
-    ? 'Today'
-    : date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
+import { Trip } from '../mockData';
 
 export interface DriverStatus {
   className: string;


### PR DESCRIPTION
## Summary
- extract `getDateKey` and `formatDateForDisplay` to `utils/dateUtils.ts`
- create `utils/driverUtils.ts` for `getDriverStatus`
- update imports in components and remove old `utils.ts`

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68531bcf80e4832fb6ad1ee7c1cb54c6