### PR TITLE
Make trip manifest panel scrollable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,7 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
   display: grid;
   height: 100vh;
   grid-template-columns: 1fr;
-  grid-template-rows: 60px 1fr auto auto;
+  grid-template-rows: 60px 1fr 1fr 150px;
   grid-template-areas:
     "header"
     "map"
@@ -66,9 +66,9 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
 }
 
 .trip-queue, .driver-roster { background-color: var(--bg-slate-blue); border-radius: 8px; border: 1px solid var(--border-color); display: flex; flex-direction: column; }
-.trip-list, .roster-scroll { overflow: auto; padding: 10px; flex-grow: 1; }
+.trip-list { overflow-y: auto; overflow-x: hidden; padding: 10px; flex-grow: 1; }
+.roster-scroll { overflow: auto; padding: 10px; flex-grow: 1; display: flex; gap: 15px; }
 .driver-roster { grid-area: roster; }
-.roster-scroll { display: flex; gap: 15px; }
 .trip-queue { grid-area: queue; }
 .panel-header { display: flex; justify-content: space-between; align-items: center; padding: 15px 20px; border-bottom: 1px solid var(--border-color); }
 .panel-header h2 { font-size: 1rem; }


### PR DESCRIPTION
## Summary
- limit scroll area of `trip-list` to vertical scrolling
- give the queue row its own share of height so content scrolls
- keep driver roster scroll behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685334e3b5f4832f8bb2a88619082089