### PR TITLE
Revert trip manifest scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,7 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
   display: grid;
   height: 100vh;
   grid-template-columns: 1fr;
-  grid-template-rows: 60px 1fr 1fr 150px;
+  grid-template-rows: 60px 1fr auto auto;
   grid-template-areas:
     "header"
     "map"
@@ -66,9 +66,9 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
 }
 
 .trip-queue, .driver-roster { background-color: var(--bg-slate-blue); border-radius: 8px; border: 1px solid var(--border-color); display: flex; flex-direction: column; }
-.trip-list { overflow-y: auto; overflow-x: hidden; padding: 10px; flex-grow: 1; }
-.roster-scroll { overflow: auto; padding: 10px; flex-grow: 1; display: flex; gap: 15px; }
+.trip-list, .roster-scroll { overflow: auto; padding: 10px; flex-grow: 1; }
 .driver-roster { grid-area: roster; }
+.roster-scroll { display: flex; gap: 15px; }
 .trip-queue { grid-area: queue; }
 .panel-header { display: flex; justify-content: space-between; align-items: center; padding: 15px 20px; border-bottom: 1px solid var(--border-color); }
 .panel-header h2 { font-size: 1rem; }


### PR DESCRIPTION
## Summary
- revert CSS change that made trip manifest vertically scrollable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853376d0b20832fb351aaaa0e7cf8ef