### PR TITLE
Add wheel scrolling to driver roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Install dependencies and start the dev server:
 npm install
 npm start
 ```
+
+In the **Active Drivers** section, you can scroll left or right using the mouse
+wheel for easier navigation.

--- a/src/components/DriverRoster.tsx
+++ b/src/components/DriverRoster.tsx
@@ -17,7 +17,14 @@ export default function DriverRoster({ drivers, trips, activeDriverId, onSelectD
       <div className="panel-header">
         <h2>Active Drivers</h2>
       </div>
-      <div className="roster-scroll" id="driver-roster-container">
+      <div
+        className="roster-scroll"
+        id="driver-roster-container"
+        onWheel={e => {
+          e.preventDefault();
+          e.currentTarget.scrollLeft += e.deltaY;
+        }}
+      >
         {drivers.map(driver => (
           <DriverCard
             key={driver.id}

--- a/src/components/__tests__/DriverRoster.test.tsx
+++ b/src/components/__tests__/DriverRoster.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DriverRoster from '../DriverRoster';
 import { Driver, Trip } from '../../mockData';
 
@@ -23,4 +23,24 @@ test('renders driver names', () => {
 
   expect(screen.getByText('Alice')).toBeInTheDocument();
   expect(screen.getByText('Bob')).toBeInTheDocument();
+});
+
+test('wheel event scrolls roster', () => {
+  const drivers: Driver[] = [
+    { id: 'd1', name: 'Alice', photo: 'a', vehicle: 'car' },
+  ];
+  const trips: Trip[] = [];
+  const { container } = render(
+    <DriverRoster
+      drivers={drivers}
+      trips={trips}
+      activeDriverId={null}
+      onSelectDriver={() => {}}
+    />
+  );
+
+  const roster = container.querySelector('#driver-roster-container') as HTMLElement;
+  roster.scrollLeft = 0;
+  fireEvent.wheel(roster, { deltaY: 30 });
+  expect(roster.scrollLeft).toBe(30);
 });


### PR DESCRIPTION
## Summary
- enable horizontal scrolling of the active driver roster via the mouse wheel
- test wheel event updates scroll position
- document the scroll feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68533e393918832f80ff63e2ea074de1