### PR TITLE
Add hidden date picker to CommandBar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ export default function App() {
         totalDrivers={totalDrivers}
         onPrevDate={() => setSelectedDate(new Date(selectedDate.getTime() - 864e5))}
         onNextDate={() => setSelectedDate(new Date(selectedDate.getTime() + 864e5))}
+        onDateChange={setSelectedDate}
       />
 
       <TripQueue

--- a/src/components/CommandBar.tsx
+++ b/src/components/CommandBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { formatDateForDisplay } from '../utils/dateUtils';
 
 interface CommandBarProps {
@@ -9,6 +9,7 @@ interface CommandBarProps {
   totalDrivers: number;
   onPrevDate: () => void;
   onNextDate: () => void;
+  onDateChange: (date: Date) => void;
 }
 
 export default function CommandBar({
@@ -19,13 +20,35 @@ export default function CommandBar({
   totalDrivers,
   onPrevDate,
   onNextDate,
+  onDateChange,
 }: CommandBarProps) {
+  const dateInputRef = useRef<HTMLInputElement>(null);
+
+  const handleDateClick = () => {
+    const input = dateInputRef.current;
+    if (!input) return;
+    if (typeof (input as any).showPicker === 'function') {
+      (input as any).showPicker();
+    } else {
+      input.focus();
+      input.click();
+    }
+  };
+
   return (
     <header className="command-bar">
       <div className="logo">Zenith</div>
       <div className="date-navigator">
         <i className="fas fa-chevron-left nav-arrow" onClick={onPrevDate} />
-        <span id="current-date">{formatDateForDisplay(selectedDate)}</span>
+        <span id="current-date" onClick={handleDateClick}>{formatDateForDisplay(selectedDate)}</span>
+        <input
+          id="date-picker"
+          type="date"
+          ref={dateInputRef}
+          style={{ position: 'absolute', left: '-9999px' }}
+          value={selectedDate.toISOString().split('T')[0]}
+          onChange={e => onDateChange(new Date(e.target.value))}
+        />
         <i className="fas fa-chevron-right nav-arrow" onClick={onNextDate} />
       </div>
       <div className="kpis" id="kpis-container">

--- a/src/components/__tests__/CommandBar.test.tsx
+++ b/src/components/__tests__/CommandBar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import CommandBar from '../CommandBar';
 import { formatDateForDisplay } from '../../utils/dateUtils';
 
@@ -15,9 +15,32 @@ test('renders KPIs and selected date', () => {
       totalDrivers={3}
       onPrevDate={() => {}}
       onNextDate={() => {}}
+      onDateChange={() => {}}
     />
   );
 
   expect(screen.getByText('Zenith')).toBeInTheDocument();
   expect(screen.getByText(formatDateForDisplay(date))).toBeInTheDocument();
+});
+
+test('clicking current date triggers date picker', () => {
+  const date = new Date('2024-01-01');
+  render(
+    <CommandBar
+      selectedDate={date}
+      pending={0}
+      totalTrips={0}
+      driversOnTrips={0}
+      totalDrivers={0}
+      onPrevDate={() => {}}
+      onNextDate={() => {}}
+      onDateChange={() => {}}
+    />
+  );
+
+  const input = document.getElementById('date-picker') as HTMLInputElement;
+  // mock showPicker if available
+  (input as any).showPicker = jest.fn();
+  fireEvent.click(screen.getByText(formatDateForDisplay(date)));
+  expect((input as any).showPicker).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add `onDateChange` prop for the CommandBar component
- open a hidden date input when clicking on the current date
- hook App into `onDateChange`
- test that clicking the current date calls `showPicker`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534195bccc832f8789ea31f6281c52