### PR TITLE
Display pickup time only on active trip cards

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -44,11 +44,13 @@ export default function TripCard({
           <span>{trip.to}</span>
         </p>
       </div>
-      <div className="trip-footer">
-        <span>
-          <i className="fas fa-clock"></i> Pickup at {trip.time}
-        </span>
-      </div>
+      {isActive && trip.time && (
+        <div className="trip-footer">
+          <span>
+            <i className="fas fa-clock"></i> Pickup at {trip.time}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -29,3 +29,49 @@ test('calls onSelect when card is clicked', () => {
   fireEvent.click(card);
   expect(onSelect).toHaveBeenCalled();
 });
+
+test('does not show pickup time when card is inactive', () => {
+  const trip: Trip = {
+    id: 't1',
+    driverId: 'd1',
+    status: 'pending',
+    passenger: 'John Doe',
+    from: 'A',
+    to: 'B',
+    time: '10:00',
+  };
+  render(
+    <TripCard
+      trip={trip}
+      isActive={false}
+      onSelect={() => {}}
+      onPassengerFilter={() => {}}
+      onShowDetails={() => {}}
+    />
+  );
+
+  expect(screen.queryByText(/Pickup at/)).not.toBeInTheDocument();
+});
+
+test('shows pickup time when card is active', () => {
+  const trip: Trip = {
+    id: 't1',
+    driverId: 'd1',
+    status: 'pending',
+    passenger: 'John Doe',
+    from: 'A',
+    to: 'B',
+    time: '10:00',
+  };
+  render(
+    <TripCard
+      trip={trip}
+      isActive={true}
+      onSelect={() => {}}
+      onPassengerFilter={() => {}}
+      onShowDetails={() => {}}
+    />
+  );
+
+  expect(screen.getByText(/Pickup at 10:00/)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show trip footer only when the trip card is active and has a time
- test that inactive cards hide the pickup time and active cards show it

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68533e0fb82c832fb79e254014a3ad5d