### PR TITLE
Add collapsible driver roster

### DIFF
--- a/src/components/DriverRoster.tsx
+++ b/src/components/DriverRoster.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Driver, Trip } from '../mockData';
 import DriverCard from './DriverCard';
 import { getDriverStatus } from '../utils/driverUtils';
@@ -12,29 +12,40 @@ interface DriverRosterProps {
 }
 
 export default function DriverRoster({ drivers, trips, activeDriverId, onSelectDriver }: DriverRosterProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
   return (
-    <footer className="driver-roster">
+    <footer className={`driver-roster${collapsed ? ' collapsed' : ''}`}> 
       <div className="panel-header">
         <h2>Active Drivers</h2>
+        <button
+          aria-label={collapsed ? 'Expand Active Drivers' : 'Collapse Active Drivers'}
+          className="collapse-btn"
+          onClick={() => setCollapsed(!collapsed)}
+        >
+          <i className={`fas fa-chevron-${collapsed ? 'up' : 'down'}`} />
+        </button>
       </div>
-      <div
-        className="roster-scroll"
-        id="driver-roster-container"
-        onWheel={e => {
-          e.preventDefault();
-          e.currentTarget.scrollLeft += e.deltaY;
-        }}
-      >
-        {drivers.map(driver => (
-          <DriverCard
-            key={driver.id}
-            driver={driver}
-            status={getDriverStatus(driver.id, trips)}
-            isActive={activeDriverId === driver.id}
-            onSelect={() => onSelectDriver(driver.id)}
-          />
-        ))}
-      </div>
+      {!collapsed && (
+        <div
+          className="roster-scroll"
+          id="driver-roster-container"
+          onWheel={e => {
+            e.preventDefault();
+            e.currentTarget.scrollLeft += e.deltaY;
+          }}
+        >
+          {drivers.map(driver => (
+            <DriverCard
+              key={driver.id}
+              driver={driver}
+              status={getDriverStatus(driver.id, trips)}
+              isActive={activeDriverId === driver.id}
+              onSelect={() => onSelectDriver(driver.id)}
+            />
+          ))}
+        </div>
+      )}
     </footer>
   );
 }

--- a/src/components/__tests__/DriverRoster.test.tsx
+++ b/src/components/__tests__/DriverRoster.test.tsx
@@ -44,3 +44,25 @@ test('wheel event scrolls roster', () => {
   fireEvent.wheel(roster, { deltaY: 30 });
   expect(roster.scrollLeft).toBe(30);
 });
+
+test('collapse button toggles roster visibility', () => {
+  const drivers: Driver[] = [
+    { id: 'd1', name: 'Alice', photo: 'a', vehicle: 'car' },
+  ];
+  const trips: Trip[] = [];
+  render(
+    <DriverRoster
+      drivers={drivers}
+      trips={trips}
+      activeDriverId={null}
+      onSelectDriver={() => {}}
+    />
+  );
+
+  const button = screen.getByRole('button');
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+  fireEvent.click(button);
+  expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  fireEvent.click(button);
+  expect(screen.getByText('Alice')).toBeInTheDocument();
+});

--- a/src/index.css
+++ b/src/index.css
@@ -87,9 +87,23 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
   gap: 15px;
 }
 .driver-roster { grid-area: roster; }
+.driver-roster.collapsed .roster-scroll {
+  display: none;
+}
 .trip-queue { grid-area: queue; min-height: 300px; }
 .panel-header { display: flex; justify-content: space-between; align-items: center; padding: 15px 20px; border-bottom: 1px solid var(--border-color); }
 .panel-header h2 { font-size: 1rem; }
+.collapse-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: color 0.2s;
+}
+.collapse-btn:hover {
+  color: var(--accent-teal);
+}
 .clear-filter-btn { background: none; border: 1px solid var(--text-secondary); color: var(--text-secondary); font-size: 0.75rem; padding: 4px 8px; border-radius: 4px; cursor: pointer; transition: all 0.2s; }
 .clear-filter-btn:hover { background-color: var(--accent-teal); color: var(--bg-deep-charcoal); border-color: var(--accent-teal); }
 .clear-filter-btn .fa-xmark { margin-right: 5px; }


### PR DESCRIPTION
## Summary
- let DriverRoster toggle a collapsed state
- style collapse button in CSS
- hide driver roster when collapsed
- test collapse behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685343cbea44832fbed41765c7228865