### PR TITLE
Add expanded trip fields

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -43,12 +43,16 @@ export default function TripCard({
           <span className="trip-arrow">&nbsp;&rarr;&nbsp;</span>
           <span>{trip.to}</span>
         </p>
+        <p className="trip-phone">
+          <i className="fas fa-phone" /> {trip.phone}
+        </p>
       </div>
       {isActive && trip.time && (
         <div className="trip-footer">
           <span>
             <i className="fas fa-clock"></i> Pickup at {trip.time}
           </span>
+          <span className="transport-type">{trip.transportType}</span>
         </div>
       )}
     </div>

--- a/src/components/TripDetails.tsx
+++ b/src/components/TripDetails.tsx
@@ -26,10 +26,40 @@ export default function TripDetails({ trip, driver, onClose }: TripDetailsProps)
         <strong>To:</strong> {trip.to}
       </p>
       <p>
+        <strong>Pickup Address:</strong> {trip.pickupAddress}
+      </p>
+      <p>
+        <strong>Dropoff Address:</strong> {trip.dropoffAddress}
+      </p>
+      <p>
         <strong>Pickup:</strong> {trip.time}
       </p>
       <p>
+        <strong>Date:</strong> {trip.date}
+      </p>
+      <p>
+        <strong>In:</strong> {trip.inTime} &nbsp;&nbsp; <strong>Out:</strong> {trip.outTime}
+      </p>
+      <p>
+        <strong>Miles:</strong> {trip.miles}
+      </p>
+      <p>
+        <strong>Transport:</strong> {trip.transportType}
+      </p>
+      <p>
+        <strong>Phone:</strong> {trip.phone}
+      </p>
+      <p>
+        <strong>Medicaid #:</strong> {trip.medicaidNumber}
+      </p>
+      <p>
+        <strong>Invoice #:</strong> {trip.invoiceNumber}
+      </p>
+      <p>
         <strong>Driver:</strong> {driver.name}
+      </p>
+      <p>
+        <strong>Notes:</strong> {trip.notes}
       </p>
     </div>
   );

--- a/src/components/__tests__/DriverRoster.test.tsx
+++ b/src/components/__tests__/DriverRoster.test.tsx
@@ -10,7 +10,26 @@ test('renders driver names', () => {
     { id: 'd2', name: 'Bob', photo: 'b', vehicle: 'van' },
   ];
   const trips: Trip[] = [
-    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00' },
+    {
+      id: 't1',
+      driverId: 'd1',
+      status: 'en-route',
+      passenger: 'P',
+      from: 'A',
+      to: 'B',
+      time: '10:00',
+      date: '2024-01-01',
+      inTime: '09:45',
+      outTime: '10:15',
+      miles: 5,
+      transportType: 'Ambulatory',
+      phone: '555-0000',
+      medicaidNumber: 'MC-TEST',
+      invoiceNumber: 'INV-TEST',
+      pickupAddress: '123 A St',
+      dropoffAddress: '456 B Ave',
+      notes: 'n/a',
+    },
   ];
   render(
     <DriverRoster

--- a/src/components/__tests__/MapContainer.test.tsx
+++ b/src/components/__tests__/MapContainer.test.tsx
@@ -9,7 +9,26 @@ test('renders markers for active trips', () => {
     d1: { name: 'Alice', photo: 'a', vehicle: 'car' },
   };
   const trips: Trip[] = [
-    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00' },
+    {
+      id: 't1',
+      driverId: 'd1',
+      status: 'en-route',
+      passenger: 'P',
+      from: 'A',
+      to: 'B',
+      time: '10:00',
+      date: '2024-01-01',
+      inTime: '09:45',
+      outTime: '10:15',
+      miles: 5,
+      transportType: 'Ambulatory',
+      phone: '555-0000',
+      medicaidNumber: 'MC-TEST',
+      invoiceNumber: 'INV-TEST',
+      pickupAddress: '123 A St',
+      dropoffAddress: '456 B Ave',
+      notes: 'n/a',
+    },
   ];
   const { container } = render(<MapContainer drivers={drivers} trips={trips} />);
   expect(container.querySelectorAll('.map-driver').length).toBeGreaterThan(0);

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -13,6 +13,17 @@ test('calls onSelect when card is clicked', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    date: '2024-01-01',
+    inTime: '09:45',
+    outTime: '10:15',
+    miles: 5,
+    transportType: 'Ambulatory',
+    phone: '555-0000',
+    medicaidNumber: 'MC-TEST',
+    invoiceNumber: 'INV-TEST',
+    pickupAddress: '123 A St',
+    dropoffAddress: '456 B Ave',
+    notes: 'n/a',
   };
   const onSelect = jest.fn();
   render(
@@ -39,6 +50,17 @@ test('does not show pickup time when card is inactive', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    date: '2024-01-01',
+    inTime: '09:45',
+    outTime: '10:15',
+    miles: 5,
+    transportType: 'Ambulatory',
+    phone: '555-0000',
+    medicaidNumber: 'MC-TEST',
+    invoiceNumber: 'INV-TEST',
+    pickupAddress: '123 A St',
+    dropoffAddress: '456 B Ave',
+    notes: 'n/a',
   };
   render(
     <TripCard
@@ -62,6 +84,17 @@ test('shows pickup time when card is active', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    date: '2024-01-01',
+    inTime: '09:45',
+    outTime: '10:15',
+    miles: 5,
+    transportType: 'Ambulatory',
+    phone: '555-0000',
+    medicaidNumber: 'MC-TEST',
+    invoiceNumber: 'INV-TEST',
+    pickupAddress: '123 A St',
+    dropoffAddress: '456 B Ave',
+    notes: 'n/a',
   };
   render(
     <TripCard

--- a/src/components/__tests__/TripDetails.test.tsx
+++ b/src/components/__tests__/TripDetails.test.tsx
@@ -13,6 +13,17 @@ test('close button triggers callback', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    date: '2024-01-01',
+    inTime: '09:45',
+    outTime: '10:15',
+    miles: 5,
+    transportType: 'Ambulatory',
+    phone: '555-0000',
+    medicaidNumber: 'MC-TEST',
+    invoiceNumber: 'INV-TEST',
+    pickupAddress: '123 A St',
+    dropoffAddress: '456 B Ave',
+    notes: 'n/a',
   };
   const driver: Driver = { id: 'd1', name: 'Driver', photo: 'a', vehicle: 'car' };
   const onClose = jest.fn();

--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -5,14 +5,38 @@ export interface Driver {
   vehicle: string;
 }
 
+export type TripStatus =
+  | 'en-route'
+  | 'at-pickup'
+  | 'in-transit'
+  | 'at-dropoff'
+  | 'complete'
+  | 'cancel'
+  | 'no_show'
+  | 'waiting'
+  | 're-assigned'
+  | 'not-confirmed'
+  | 'pending';
+
 export interface Trip {
   id: string;
   driverId: string;
-  status: 'en-route' | 'at-pickup' | 'in-transit' | 'complete' | 'pending';
+  status: TripStatus;
   passenger: string;
   from: string;
   to: string;
   time: string;
+  date: string;
+  inTime: string;
+  outTime: string;
+  miles: number;
+  transportType: string;
+  phone: string;
+  medicaidNumber: string;
+  invoiceNumber: string;
+  pickupAddress: string;
+  dropoffAddress: string;
+  notes: string;
 }
 
 export const MOCK_DRIVERS: Record<string, Omit<Driver, 'id'>> = {
@@ -28,11 +52,87 @@ function getDateKey(date: Date) {
 
 export const MOCK_SCHEDULE: Record<string, Trip[]> = {
   [getDateKey(new Date())]: [
-    { id: 'zt-819', driverId: 'd1', status: 'en-route', passenger: 'Dr. Evelyn Reed', from: 'Grand Medical Center', to: "Oakwood Int'l Airport", time: '13:30' },
-    { id: 'zt-820', driverId: 'd2', status: 'at-pickup', passenger: 'Marcus Thorne', from: '123 Market St', to: 'Westside Conference Hall', time: '14:00' },
-    { id: 'zt-822', driverId: 'd4', status: 'in-transit', passenger: 'Dr. Evelyn Reed', from: "Oakwood Int'l Airport", to: 'The Landon Hotel', time: '18:00' },
+    {
+      id: 'zt-819',
+      driverId: 'd1',
+      status: 'en-route',
+      passenger: 'Dr. Evelyn Reed',
+      from: 'Grand Medical Center',
+      to: "Oakwood Int'l Airport",
+      time: '13:30',
+      date: getDateKey(new Date()),
+      inTime: '13:15',
+      outTime: '13:45',
+      miles: 25,
+      transportType: 'Ambulatory',
+      phone: '555-1010',
+      medicaidNumber: 'MC-001',
+      invoiceNumber: 'INV-819',
+      pickupAddress: '123 Health Way',
+      dropoffAddress: '1 Airport Rd',
+      notes: 'Needs assistance with luggage',
+    },
+    {
+      id: 'zt-820',
+      driverId: 'd2',
+      status: 'at-pickup',
+      passenger: 'Marcus Thorne',
+      from: '123 Market St',
+      to: 'Westside Conference Hall',
+      time: '14:00',
+      date: getDateKey(new Date()),
+      inTime: '13:50',
+      outTime: '14:20',
+      miles: 10,
+      transportType: 'Wheelchair',
+      phone: '555-2020',
+      medicaidNumber: 'MC-002',
+      invoiceNumber: 'INV-820',
+      pickupAddress: '123 Market St',
+      dropoffAddress: '456 Conference Rd',
+      notes: 'Wheelchair accessible vehicle required',
+    },
+    {
+      id: 'zt-822',
+      driverId: 'd4',
+      status: 'in-transit',
+      passenger: 'Dr. Evelyn Reed',
+      from: "Oakwood Int'l Airport",
+      to: 'The Landon Hotel',
+      time: '18:00',
+      date: getDateKey(new Date()),
+      inTime: '17:45',
+      outTime: '18:30',
+      miles: 8,
+      transportType: 'Ambulatory',
+      phone: '555-1010',
+      medicaidNumber: 'MC-001',
+      invoiceNumber: 'INV-822',
+      pickupAddress: '1 Airport Rd',
+      dropoffAddress: '500 Hotel Ave',
+      notes: 'Return trip',
+    },
   ],
   [getDateKey(new Date(Date.now() - 864e5))]: [
-    { id: 'zt-755', driverId: 'd3', status: 'complete', passenger: 'Chloe Davis', from: 'Art Museum', to: 'The Landon Hotel', time: '15:00' },
+    {
+      id: 'zt-755',
+      driverId: 'd3',
+      status: 'complete',
+      passenger: 'Chloe Davis',
+      from: 'Art Museum',
+      to: 'The Landon Hotel',
+      time: '15:00',
+      date: getDateKey(new Date(Date.now() - 864e5)),
+      inTime: '14:45',
+      outTime: '15:30',
+      miles: 5,
+      transportType: 'Ambulatory',
+      phone: '555-3030',
+      medicaidNumber: 'MC-003',
+      invoiceNumber: 'INV-755',
+      pickupAddress: '200 Art Way',
+      dropoffAddress: '500 Hotel Ave',
+      notes: 'Patient enjoyed museum visit',
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- expand `Trip` type with more fields
- include additional statuses in `TripStatus`
- update mock trips with sample data
- show phone & transport type on `TripCard`
- show full details on `TripDetails`
- adjust component tests for new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685343da7fd4832fbce0563c110bb57a