### PR TITLE
Add driver status support for additional states

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -209,11 +209,15 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
 .status-text-available { color: var(--status-complete); }
 .status-text-progress { color: var(--status-progress); }
 .status-text-arrived { color: var(--status-arrived); }
+.status-text-cancel { color: var(--status-urgent); }
+.status-text-no-show { color: var(--status-urgent); }
 
 .status-pill { display: inline-block; padding: 4px 10px; border-radius: 12px; font-size: 0.75rem; font-weight: 600; }
 .status-pill-available { background-color: rgba(46, 213, 115, 0.15); color: var(--status-complete); }
 .status-pill-progress { background-color: rgba(254, 202, 87, 0.15); color: var(--status-progress); }
 .status-pill-arrived { background-color: rgba(74, 144, 226, 0.15); color: var(--status-arrived); }
+.status-pill-cancel { background-color: rgba(255, 71, 87, 0.15); color: var(--status-urgent); }
+.status-pill-no-show { background-color: rgba(255, 71, 87, 0.15); color: var(--status-urgent); }
 
 .map-container { grid-area: map; background: var(--bg-deep-charcoal) url('data:image/svg+xml,%3Csvg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="%232a2f42" fill-opacity="0.4" fill-rule="evenodd"%3E%3Cpath d="M0 40L40 0H20L0 20M40 40V20L20 40"/%3E%3C/g%3E%3C/svg%3E'); border-radius: 8px; border: 1px solid var(--border-color); position: relative; overflow: hidden; }
 .map-icon { position: absolute; cursor: pointer; animation: fade-in 0.3s; }

--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -8,7 +8,15 @@ export interface Driver {
 export interface Trip {
   id: string;
   driverId: string;
-  status: 'en-route' | 'at-pickup' | 'in-transit' | 'complete' | 'pending';
+  status:
+    | 'en-route'
+    | 'at-pickup'
+    | 'at-dropoff'
+    | 'in-transit'
+    | 'cancel'
+    | 'no_show'
+    | 'complete'
+    | 'pending';
   passenger: string;
   from: string;
   to: string;

--- a/src/utils/__tests__/driverUtils.test.ts
+++ b/src/utils/__tests__/driverUtils.test.ts
@@ -1,0 +1,33 @@
+import { getDriverStatus } from '../driverUtils';
+import { Trip } from '../../mockData';
+
+describe('getDriverStatus', () => {
+  const baseTrip = {
+    id: 't1',
+    driverId: 'd1',
+    passenger: '',
+    from: '',
+    to: '',
+    time: '',
+  } as const;
+
+  test('maps at-dropoff status', () => {
+    const trips: Trip[] = [{ ...baseTrip, status: 'at-dropoff' }];
+    expect(getDriverStatus('d1', trips)).toEqual({ className: 'status-pill-arrived', text: 'At Dropoff' });
+  });
+
+  test('maps cancel status', () => {
+    const trips: Trip[] = [{ ...baseTrip, status: 'cancel' }];
+    expect(getDriverStatus('d1', trips)).toEqual({ className: 'status-pill-cancel', text: 'Canceled' });
+  });
+
+  test('maps no_show status', () => {
+    const trips: Trip[] = [{ ...baseTrip, status: 'no_show' }];
+    expect(getDriverStatus('d1', trips)).toEqual({ className: 'status-pill-no-show', text: 'No Show' });
+  });
+
+  test('returns Available for complete status', () => {
+    const trips: Trip[] = [{ ...baseTrip, status: 'complete' }];
+    expect(getDriverStatus('d1', trips)).toEqual({ className: 'status-pill-available', text: 'Available' });
+  });
+});

--- a/src/utils/driverUtils.ts
+++ b/src/utils/driverUtils.ts
@@ -17,6 +17,12 @@ export function getDriverStatus(driverId: string, trips: Trip[]): DriverStatus {
         return { className: 'status-pill-arrived', text: 'At Pickup' };
       case 'in-transit':
         return { className: 'status-pill-progress', text: 'In-Transit' };
+      case 'at-dropoff':
+        return { className: 'status-pill-arrived', text: 'At Dropoff' };
+      case 'cancel':
+        return { className: 'status-pill-cancel', text: 'Canceled' };
+      case 'no_show':
+        return { className: 'status-pill-no-show', text: 'No Show' };
     }
   }
   return { className: 'status-pill-available', text: 'Available' };


### PR DESCRIPTION
## Summary
- extend Trip status union with more states
- map new driver statuses in `getDriverStatus`
- add cancel/no-show pill styles
- test new status mappings

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685343e1cb00832fbb75dc516b73b91b