### PR TITLE
Use coordinates for map markers

### DIFF
--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -19,7 +19,7 @@ export default function MapContainer({ drivers, trips }: MapContainerProps) {
             key={id}
             className="map-icon map-driver"
             data-status={activeTrip.status}
-            style={{ top: `${Math.random() * 80 + 10}%`, left: `${Math.random() * 80 + 10}%` }}
+            style={{ top: `${activeTrip.lat}%`, left: `${activeTrip.lng}%` }}
           >
             <div className="icon-body"></div>
           </div>

--- a/src/components/__tests__/DriverRoster.test.tsx
+++ b/src/components/__tests__/DriverRoster.test.tsx
@@ -10,7 +10,7 @@ test('renders driver names', () => {
     { id: 'd2', name: 'Bob', photo: 'b', vehicle: 'van' },
   ];
   const trips: Trip[] = [
-    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00' },
+    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00', lat: 10, lng: 20 },
   ];
   render(
     <DriverRoster

--- a/src/components/__tests__/MapContainer.test.tsx
+++ b/src/components/__tests__/MapContainer.test.tsx
@@ -9,7 +9,7 @@ test('renders markers for active trips', () => {
     d1: { name: 'Alice', photo: 'a', vehicle: 'car' },
   };
   const trips: Trip[] = [
-    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00' },
+    { id: 't1', driverId: 'd1', status: 'en-route', passenger: 'P', from: 'A', to: 'B', time: '10:00', lat: 50, lng: 40 },
   ];
   const { container } = render(<MapContainer drivers={drivers} trips={trips} />);
   expect(container.querySelectorAll('.map-driver').length).toBeGreaterThan(0);

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -13,6 +13,8 @@ test('calls onSelect when card is clicked', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    lat: 12,
+    lng: 34,
   };
   const onSelect = jest.fn();
   render(
@@ -39,6 +41,8 @@ test('does not show pickup time when card is inactive', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    lat: 12,
+    lng: 34,
   };
   render(
     <TripCard
@@ -62,6 +66,8 @@ test('shows pickup time when card is active', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    lat: 12,
+    lng: 34,
   };
   render(
     <TripCard

--- a/src/components/__tests__/TripDetails.test.tsx
+++ b/src/components/__tests__/TripDetails.test.tsx
@@ -13,6 +13,8 @@ test('close button triggers callback', () => {
     from: 'A',
     to: 'B',
     time: '10:00',
+    lat: 30,
+    lng: 60,
   };
   const driver: Driver = { id: 'd1', name: 'Driver', photo: 'a', vehicle: 'car' };
   const onClose = jest.fn();

--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -13,6 +13,8 @@ export interface Trip {
   from: string;
   to: string;
   time: string;
+  lat: number;
+  lng: number;
 }
 
 export const MOCK_DRIVERS: Record<string, Omit<Driver, 'id'>> = {
@@ -28,11 +30,51 @@ function getDateKey(date: Date) {
 
 export const MOCK_SCHEDULE: Record<string, Trip[]> = {
   [getDateKey(new Date())]: [
-    { id: 'zt-819', driverId: 'd1', status: 'en-route', passenger: 'Dr. Evelyn Reed', from: 'Grand Medical Center', to: "Oakwood Int'l Airport", time: '13:30' },
-    { id: 'zt-820', driverId: 'd2', status: 'at-pickup', passenger: 'Marcus Thorne', from: '123 Market St', to: 'Westside Conference Hall', time: '14:00' },
-    { id: 'zt-822', driverId: 'd4', status: 'in-transit', passenger: 'Dr. Evelyn Reed', from: "Oakwood Int'l Airport", to: 'The Landon Hotel', time: '18:00' },
+    {
+      id: 'zt-819',
+      driverId: 'd1',
+      status: 'en-route',
+      passenger: 'Dr. Evelyn Reed',
+      from: 'Grand Medical Center',
+      to: "Oakwood Int'l Airport",
+      time: '13:30',
+      lat: 32,
+      lng: 20,
+    },
+    {
+      id: 'zt-820',
+      driverId: 'd2',
+      status: 'at-pickup',
+      passenger: 'Marcus Thorne',
+      from: '123 Market St',
+      to: 'Westside Conference Hall',
+      time: '14:00',
+      lat: 45,
+      lng: 70,
+    },
+    {
+      id: 'zt-822',
+      driverId: 'd4',
+      status: 'in-transit',
+      passenger: 'Dr. Evelyn Reed',
+      from: "Oakwood Int'l Airport",
+      to: 'The Landon Hotel',
+      time: '18:00',
+      lat: 60,
+      lng: 40,
+    },
   ],
   [getDateKey(new Date(Date.now() - 864e5))]: [
-    { id: 'zt-755', driverId: 'd3', status: 'complete', passenger: 'Chloe Davis', from: 'Art Museum', to: 'The Landon Hotel', time: '15:00' },
+    {
+      id: 'zt-755',
+      driverId: 'd3',
+      status: 'complete',
+      passenger: 'Chloe Davis',
+      from: 'Art Museum',
+      to: 'The Landon Hotel',
+      time: '15:00',
+      lat: 80,
+      lng: 55,
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- add `lat` and `lng` fields to `Trip` data
- update `MOCK_SCHEDULE` with coordinates
- position map markers using trip coordinates
- update tests to provide coordinates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685343fe1a00832f96326c0281d53e73