### PR TITLE
Add transport type icons on trip cards

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -1,6 +1,19 @@
 import React from 'react';
 import { Trip } from '../mockData';
 
+function getTransportIcon(type: string): string {
+  switch (type.toLowerCase()) {
+    case 'ambulatory':
+      return 'fa-person-walking';
+    case 'wheelchair':
+      return 'fa-wheelchair';
+    case 'stretcher':
+      return 'fa-bed';
+    default:
+      return 'fa-car';
+  }
+}
+
 interface TripCardProps {
   trip: Trip;
   isActive: boolean;
@@ -49,7 +62,12 @@ export default function TripCard({
           <span>
             <i className="fas fa-clock"></i> Pickup at {trip.time}
           </span>
-          <span className="transport-type">{trip.transportType}</span>
+          <span
+            className="transport-type-icon"
+            aria-label={trip.transportType}
+          >
+            <i className={`fas ${getTransportIcon(trip.transportType)}`}></i>
+          </span>
         </div>
       )}
     </div>

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -108,3 +108,39 @@ test('shows pickup time when card is active', () => {
 
   expect(screen.getByText(/Pickup at 10:00/)).toBeInTheDocument();
 });
+
+test('shows transport icon when card is active', () => {
+  const trip: Trip = {
+    id: 't1',
+    driverId: 'd1',
+    status: 'pending',
+    passenger: 'John Doe',
+    from: 'A',
+    to: 'B',
+    time: '10:00',
+    date: '2024-01-01',
+    inTime: '09:45',
+    outTime: '10:15',
+    miles: 5,
+    transportType: 'Wheelchair',
+    phone: '555-0000',
+    medicaidNumber: 'MC-TEST',
+    invoiceNumber: 'INV-TEST',
+    pickupAddress: '123 A St',
+    dropoffAddress: '456 B Ave',
+    notes: 'n/a',
+  };
+  render(
+    <TripCard
+      trip={trip}
+      isActive={true}
+      onSelect={() => {}}
+      onPassengerFilter={() => {}}
+      onShowDetails={() => {}}
+    />
+  );
+
+  const icon = screen.getByLabelText('Wheelchair');
+  expect(icon).toBeInTheDocument();
+  expect(icon.querySelector('i')).toHaveClass('fa-wheelchair');
+});

--- a/src/index.css
+++ b/src/index.css
@@ -166,6 +166,13 @@ body { font-family: var(--font-family); background-color: var(--bg-deep-charcoal
   border-top: 1px solid var(--border-color);
   font-size: 0.75rem;
   color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+}
+
+.transport-type-icon {
+  margin-left: auto;
+  color: var(--text-secondary);
 }
 
 .trip-details {


### PR DESCRIPTION
## Summary
- show an icon for each transport type in TripCard
- style icon and trip footer
- test TripCard displays correct transport icon

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534a670f74832fbf159dcd811cb1ef