### PR TITLE
Add tooltip for transport type in TripCard

### DIFF
--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -65,6 +65,7 @@ export default function TripCard({
           <span
             className="transport-type-icon"
             aria-label={trip.transportType}
+            title={trip.transportType}
           >
             <i className={`fas ${getTransportIcon(trip.transportType)}`}></i>
           </span>

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -143,4 +143,5 @@ test('shows transport icon when card is active', () => {
   const icon = screen.getByLabelText('Wheelchair');
   expect(icon).toBeInTheDocument();
   expect(icon.querySelector('i')).toHaveClass('fa-wheelchair');
+  expect(icon).toHaveAttribute('title', 'Wheelchair');
 });


### PR DESCRIPTION
## Summary
- show tooltip for transport type icon in TripCard
- check for tooltip in TripCard test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534c928c28832fb80993dc1ef3b5f3