### PR TITLE
Add Redux slices for detailed data and update components

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom';
+
+// polyfill matchMedia for tests
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as any;
+}

--- a/src/components/DriverRoster.tsx
+++ b/src/components/DriverRoster.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { Driver, Trip } from '../mockData';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store';
+import { getDateKey } from '../utils/dateUtils';
 import DriverCard from './DriverCard';
 import { getDriverStatus } from '../utils/driverUtils';
 
 
 interface DriverRosterProps {
-  drivers: Driver[];
-  trips: Trip[];
+  selectedDate: Date;
   activeDriverId: string | null;
   onSelectDriver: (driverId: string) => void;
   collapsed: boolean;
@@ -14,16 +15,20 @@ interface DriverRosterProps {
 }
 
 export default function DriverRoster({
-  drivers,
-  trips,
+  selectedDate,
   activeDriverId,
   onSelectDriver,
   collapsed,
   onToggleCollapse,
 }: DriverRosterProps) {
+  const drivers = useSelector((s: RootState) => s.driverDetails);
+  const schedule = useSelector((s: RootState) => s.tripsDetails);
+  const dateKey = getDateKey(selectedDate);
+  const trips = schedule[dateKey] || [];
+  const driversList = Object.entries(drivers).map(([id, d]) => ({ id, ...d }));
 
   return (
-    <footer className={`driver-roster${collapsed ? ' collapsed' : ''}`}> 
+    <footer className={`driver-roster${collapsed ? ' collapsed' : ''}`}>
       <div className="panel-header">
         <h2>Active Drivers</h2>
         <button
@@ -43,7 +48,7 @@ export default function DriverRoster({
             e.currentTarget.scrollLeft += e.deltaY;
           }}
         >
-          {drivers.map(driver => (
+          {driversList.map(driver => (
             <DriverCard
               key={driver.id}
               driver={driver}

--- a/src/components/TripQueue.tsx
+++ b/src/components/TripQueue.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Trip, Driver } from '../mockData';
+import { RootState } from '../store';
+import { getDateKey } from '../utils/dateUtils';
 import TripCard from './TripCard';
 import TripDetails from './TripDetails';
 
 type FilterType = 'none' | 'trip' | 'driver' | 'passenger';
 
 interface TripQueueProps {
-  trips: Trip[];
-  drivers: Record<string, Omit<Driver, 'id'>>;
+  selectedDate: Date;
   filterType: FilterType;
   filterId: string | null;
   detailedTrip: Trip | null;
@@ -20,8 +22,7 @@ interface TripQueueProps {
 }
 
 export default function TripQueue({
-  trips,
-  drivers,
+  selectedDate,
   filterType,
   filterId,
   detailedTrip,
@@ -32,6 +33,18 @@ export default function TripQueue({
   onCloseTripDetails,
   onClearFilter,
 }: TripQueueProps) {
+  const drivers = useSelector((s: RootState) => s.driverDetails);
+  const schedule = useSelector((s: RootState) => s.tripsDetails);
+  const dateKey = getDateKey(selectedDate);
+  let trips = schedule[dateKey] || [];
+
+  if (filterType === 'trip') {
+    trips = trips.filter(t => t.id === filterId);
+  } else if (filterType === 'driver') {
+    trips = trips.filter(t => t.driverId === filterId);
+  } else if (filterType === 'passenger') {
+    trips = trips.filter(t => t.passenger === filterId);
+  }
   return (
     <aside className="trip-queue">
       <div className="panel-header" id="trip-panel-header">

--- a/src/components/__tests__/DriverRoster.test.tsx
+++ b/src/components/__tests__/DriverRoster.test.tsx
@@ -1,65 +1,38 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import store from '../../store';
 import DriverRoster from '../DriverRoster';
-import { Driver, Trip } from '../../mockData';
 
 test('renders driver names', () => {
-  const drivers: Driver[] = [
-    { id: 'd1', name: 'Alice', photo: 'a', vehicle: 'car' },
-    { id: 'd2', name: 'Bob', photo: 'b', vehicle: 'van' },
-  ];
-  const trips: Trip[] = [
-    {
-      id: 't1',
-      driverId: 'd1',
-      status: 'en-route',
-      passenger: 'P',
-      from: 'A',
-      to: 'B',
-      time: '10:00',
-      date: '2024-01-01',
-      inTime: '09:45',
-      outTime: '10:15',
-      miles: 5,
-      transportType: 'Ambulatory',
-      phone: '555-0000',
-      medicaidNumber: 'MC-TEST',
-      invoiceNumber: 'INV-TEST',
-      pickupAddress: '123 A St',
-      dropoffAddress: '456 B Ave',
-      notes: 'n/a',
-    },
-  ];
   render(
-    <DriverRoster
-      drivers={drivers}
-      trips={trips}
-      activeDriverId={null}
-      onSelectDriver={() => {}}
-      collapsed={false}
-      onToggleCollapse={() => {}}
-    />
+    <Provider store={store}>
+      <DriverRoster
+        selectedDate={new Date()}
+        activeDriverId={null}
+        onSelectDriver={() => {}}
+        collapsed={false}
+        onToggleCollapse={() => {}}
+      />
+    </Provider>
   );
 
-  expect(screen.getByText('Alice')).toBeInTheDocument();
-  expect(screen.getByText('Bob')).toBeInTheDocument();
+  expect(screen.getByText('Elena Vance')).toBeInTheDocument();
+  expect(screen.getByText('Ben Carter')).toBeInTheDocument();
 });
 
 test('wheel event scrolls roster', () => {
-  const drivers: Driver[] = [
-    { id: 'd1', name: 'Alice', photo: 'a', vehicle: 'car' },
-  ];
-  const trips: Trip[] = [];
   const { container } = render(
-    <DriverRoster
-      drivers={drivers}
-      trips={trips}
-      activeDriverId={null}
-      onSelectDriver={() => {}}
-      collapsed={false}
-      onToggleCollapse={() => {}}
-    />
+    <Provider store={store}>
+      <DriverRoster
+        selectedDate={new Date()}
+        activeDriverId={null}
+        onSelectDriver={() => {}}
+        collapsed={false}
+        onToggleCollapse={() => {}}
+      />
+    </Provider>
   );
 
   const roster = container.querySelector('#driver-roster-container') as HTMLElement;
@@ -69,24 +42,20 @@ test('wheel event scrolls roster', () => {
 });
 
 test('collapse button toggles roster visibility', () => {
-  const drivers: Driver[] = [
-    { id: 'd1', name: 'Alice', photo: 'a', vehicle: 'car' },
-  ];
-  const trips: Trip[] = [];
-
   function Wrapper() {
     const [collapsed, setCollapsed] = React.useState(false);
     return (
-      <div className={`dashboard-container${collapsed ? ' roster-collapsed' : ''}`}>
-        <DriverRoster
-          drivers={drivers}
-          trips={trips}
-          activeDriverId={null}
-          onSelectDriver={() => {}}
-          collapsed={collapsed}
-          onToggleCollapse={() => setCollapsed(c => !c)}
-        />
-      </div>
+      <Provider store={store}>
+        <div className={`dashboard-container${collapsed ? ' roster-collapsed' : ''}`}>
+          <DriverRoster
+            selectedDate={new Date()}
+            activeDriverId={null}
+            onSelectDriver={() => {}}
+            collapsed={collapsed}
+            onToggleCollapse={() => setCollapsed(c => !c)}
+          />
+        </div>
+      </Provider>
     );
   }
 
@@ -95,12 +64,12 @@ test('collapse button toggles roster visibility', () => {
   const button = screen.getByRole('button');
   const dashboard = container.querySelector('.dashboard-container') as HTMLElement;
 
-  expect(screen.getByText('Alice')).toBeInTheDocument();
+  expect(screen.getByText('Elena Vance')).toBeInTheDocument();
   expect(dashboard.classList.contains('roster-collapsed')).toBe(false);
   fireEvent.click(button);
-  expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  expect(screen.queryByText('Elena Vance')).not.toBeInTheDocument();
   expect(dashboard.classList.contains('roster-collapsed')).toBe(true);
   fireEvent.click(button);
-  expect(screen.getByText('Alice')).toBeInTheDocument();
+  expect(screen.getByText('Elena Vance')).toBeInTheDocument();
   expect(dashboard.classList.contains('roster-collapsed')).toBe(false);
 });

--- a/src/components/__tests__/TripQueue.test.tsx
+++ b/src/components/__tests__/TripQueue.test.tsx
@@ -1,23 +1,26 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import store from '../../store';
 import TripQueue from '../TripQueue';
 
 test('shows message when no trips are available', () => {
   render(
-    <TripQueue
-      trips={[]}
-      drivers={{}}
-      filterType="none"
-      filterId={null}
-      detailedTrip={null}
-      activeTripId={null}
-      onSelectTrip={() => {}}
-      onPassengerFilter={() => {}}
-      onShowTripDetails={() => {}}
-      onCloseTripDetails={() => {}}
-      onClearFilter={() => {}}
-    />
+    <Provider store={store}>
+      <TripQueue
+        selectedDate={new Date('2000-01-01')}
+        filterType="none"
+        filterId={null}
+        detailedTrip={null}
+        activeTripId={null}
+        onSelectTrip={() => {}}
+        onPassengerFilter={() => {}}
+        onShowTripDetails={() => {}}
+        onCloseTripDetails={() => {}}
+        onClearFilter={() => {}}
+      />
+    </Provider>
   );
 
   expect(screen.getByText('No trips found.')).toBeInTheDocument();

--- a/src/store/driverDetailsSlice.ts
+++ b/src/store/driverDetailsSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Driver, MOCK_DRIVERS } from '../mockData';
+
+export type DriverDetailsState = Record<string, Omit<Driver, 'id'>>;
+
+const initialState: DriverDetailsState = { ...MOCK_DRIVERS };
+
+const driverDetailsSlice = createSlice({
+  name: 'driverDetails',
+  initialState,
+  reducers: {
+    setDriverDetails(_, action: PayloadAction<DriverDetailsState>) {
+      return action.payload;
+    },
+    updateDriverDetail(state, action: PayloadAction<Driver>) {
+      const { id, ...rest } = action.payload;
+      state[id] = rest;
+    },
+  },
+});
+
+export const { setDriverDetails, updateDriverDetail } = driverDetailsSlice.actions;
+export default driverDetailsSlice.reducer;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,12 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit';
 import driversReducer from './driversSlice';
 import tripsReducer from './tripsSlice';
+import driverDetailsReducer from './driverDetailsSlice';
+import tripsDetailsReducer from './tripsDetailsSlice';
 import mapUiReducer from './mapUiSlice';
 
 const store = configureStore({
   reducer: {
     drivers: driversReducer,
     trips: tripsReducer,
+    driverDetails: driverDetailsReducer,
+    tripsDetails: tripsDetailsReducer,
     mapUi: mapUiReducer,
   },
 });

--- a/src/store/tripsDetailsSlice.ts
+++ b/src/store/tripsDetailsSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Trip, MOCK_SCHEDULE } from '../mockData';
+
+export type TripsScheduleState = Record<string, Trip[]>;
+
+const initialState: TripsScheduleState = { ...MOCK_SCHEDULE };
+
+const tripsDetailsSlice = createSlice({
+  name: 'tripsDetails',
+  initialState,
+  reducers: {
+    setTripsSchedule(_, action: PayloadAction<TripsScheduleState>) {
+      return action.payload;
+    },
+    updateTrip(state, action: PayloadAction<Trip>) {
+      const { date } = action.payload;
+      const list = state[date] || [];
+      const idx = list.findIndex(t => t.id === action.payload.id);
+      if (idx !== -1) list[idx] = action.payload;
+      else list.push(action.payload);
+      state[date] = list;
+    },
+  },
+});
+
+export const { setTripsSchedule, updateTrip } = tripsDetailsSlice.actions;
+export default tripsDetailsSlice.reducer;


### PR DESCRIPTION
## Summary
- create `driverDetailsSlice` and `tripsDetailsSlice`
- load detailed mock data into Redux in `App`
- read trip and driver details from store in `DriverRoster` and `TripQueue`
- update tests for new Redux-connected components
- polyfill `matchMedia` for Jest

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854328d60d4832f89224c1b41891085