### PR TITLE
Rename map wrapper

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -83,7 +83,7 @@ export default function Map() {
   useEffect(updatePositions, [drivers, trips]);
 
   return (
-    <div className="map-wrapper">
+    <div className="map-container">
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
       {drivers.map(d =>
         driverPos[d.id] ? (

--- a/src/components/MapStyles.css
+++ b/src/components/MapStyles.css
@@ -1,4 +1,4 @@
-.map-wrapper {
+.map-container {
   position: relative;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- rename Map.tsx outer wrapper className to `map-container`
- adjust styles in MapStyles.css to use `.map-container`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685435ab0d5c832fb1fa5e84840663a2