### PR TITLE
Add cleanup to map initialization

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -60,6 +60,12 @@ export default function Map() {
     }
     updatePositions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => {
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
+    };
   }, [ui.isDarkMode]);
 
   const updatePositions = () => {


### PR DESCRIPTION
## Summary
- ensure the map instance is removed when `Map` unmounts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68543707a0c4832fb2af4240837540c8