### PR TITLE
Extend Trip types for driver/status

### DIFF
--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -179,18 +179,24 @@ export const MOCK_DRIVERS_MAP: MapDriver[] = Object.entries(MOCK_DRIVERS).map(
 export const MOCK_TRIPS_MAP: MapTrip[] = [
   {
     id: 't1',
+    driverId: 'd1',
+    status: 'pending',
     passengerName: 'Alice',
     pickup: { lat: 40.7127, lng: -74.0059 },
     dropoff: { lat: 40.721, lng: -74.01 },
   },
   {
     id: 't2',
+    driverId: 'd2',
+    status: 'en-route',
     passengerName: 'Bob',
     pickup: { lat: 40.718, lng: -74.012 },
     dropoff: { lat: 40.722, lng: -74.003 },
   },
   {
     id: 't3',
+    driverId: 'd3',
+    status: 'in-transit',
     passengerName: 'Charlie',
     pickup: { lat: 40.709, lng: -74.01 },
     dropoff: { lat: 40.714, lng: -74.016 },

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,12 @@ export interface Driver {
   status: string;
 }
 
+import type { TripStatus } from './mockData';
+
 export interface Trip {
   id: string;
+  driverId: string;
+  status: TripStatus;
   passengerName: string;
   pickup: { lat: number; lng: number };
   dropoff: { lat: number; lng: number };


### PR DESCRIPTION
## Summary
- extend `Trip` interface with `driverId` and `status`
- set matching `driverId` and `status` on `MOCK_TRIPS_MAP` entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543ef60c50832fa7f5b37d3db64151