### PR TITLE
Add geocoding mapping for trip schedule

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,12 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setDriverDetails } from './store/driverDetailsSlice';
 import { setTripsSchedule } from './store/tripsDetailsSlice';
+import { setTrips } from './store/tripsSlice';
 import { RootState } from './store';
 import './index.css';
 import { MOCK_DRIVERS, MOCK_SCHEDULE, Trip, Driver } from './mockData';
 import { getDateKey } from "./utils/dateUtils";
+import { mapScheduleToTrips } from './utils/tripUtils';
 import {
   CommandBar,
   TripQueue,
@@ -23,6 +25,14 @@ export default function App() {
   useEffect(() => {
     dispatch(setDriverDetails(MOCK_DRIVERS));
     dispatch(setTripsSchedule(MOCK_SCHEDULE));
+    (async () => {
+      try {
+        const mapTrips = await mapScheduleToTrips(MOCK_SCHEDULE);
+        dispatch(setTrips(mapTrips));
+      } catch {
+        // ignore geocode errors
+      }
+    })();
   }, [dispatch]);
 
   const [selectedDate, setSelectedDate] = useState(new Date());

--- a/src/store/tripsSlice.ts
+++ b/src/store/tripsSlice.ts
@@ -1,8 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Trip } from '../types';
-import { MOCK_TRIPS_MAP } from '../mockData';
 
-const initialState: Trip[] = [...MOCK_TRIPS_MAP];
+const initialState: Trip[] = [];
 
 const tripsSlice = createSlice({
   name: 'trips',

--- a/src/utils/__tests__/tripUtils.test.ts
+++ b/src/utils/__tests__/tripUtils.test.ts
@@ -1,0 +1,51 @@
+import { mapScheduleToTrips } from '../tripUtils';
+import * as geocode from '../geocodeAddress';
+import type { Trip } from '../../mockData';
+
+test('maps schedule trips to map trips using geocoded addresses', async () => {
+  const schedule: Record<string, Trip[]> = {
+    '2024-01-01': [
+      {
+        id: 't1',
+        driverId: 'd1',
+        status: 'pending',
+        passenger: 'Joe',
+        from: 'A',
+        to: 'B',
+        time: '10:00',
+        date: '2024-01-01',
+        inTime: '09:45',
+        outTime: '10:15',
+        miles: 1,
+        transportType: 'Ambulatory',
+        phone: '555',
+        medicaidNumber: 'MC',
+        invoiceNumber: 'INV',
+        pickupAddress: '123 Start St',
+        dropoffAddress: '456 End Ave',
+        notes: 'n/a',
+      },
+    ],
+  };
+
+  const geoMock = jest.spyOn(geocode, 'geocodeAddress');
+  geoMock.mockResolvedValueOnce({ lat: 1, lng: 2 });
+  geoMock.mockResolvedValueOnce({ lat: 3, lng: 4 });
+
+  const result = await mapScheduleToTrips(schedule);
+
+  expect(geoMock).toHaveBeenCalledWith('123 Start St');
+  expect(geoMock).toHaveBeenCalledWith('456 End Ave');
+  expect(result).toEqual([
+    {
+      id: 't1',
+      driverId: 'd1',
+      status: 'pending',
+      passengerName: 'Joe',
+      pickup: { lat: 1, lng: 2 },
+      dropoff: { lat: 3, lng: 4 },
+    },
+  ]);
+
+  geoMock.mockRestore();
+});

--- a/src/utils/tripUtils.ts
+++ b/src/utils/tripUtils.ts
@@ -1,0 +1,25 @@
+import { Trip as ScheduleTrip } from '../mockData';
+import type { Trip as MapTrip } from '../types';
+import { geocodeAddress } from './geocodeAddress';
+
+export async function mapScheduleToTrips(schedule: Record<string, ScheduleTrip[]>): Promise<MapTrip[]> {
+  const tasks: Promise<MapTrip>[] = [];
+  for (const trips of Object.values(schedule)) {
+    for (const trip of trips) {
+      tasks.push(
+        Promise.all([
+          geocodeAddress(trip.pickupAddress),
+          geocodeAddress(trip.dropoffAddress),
+        ]).then(([pickup, dropoff]) => ({
+          id: trip.id,
+          driverId: trip.driverId,
+          status: trip.status,
+          passengerName: trip.passenger,
+          pickup,
+          dropoff,
+        }))
+      );
+    }
+  }
+  return Promise.all(tasks);
+}


### PR DESCRIPTION
## Summary
- map trip schedule addresses to map coordinates
- dispatch converted trips on app load
- store trips initially empty
- test trip schedule to map mapping

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685455cf9abc832f92bb7c84fb66c5db