### PR TITLE
Filter map markers when manifest filtered

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ export default function App() {
         onToggleCollapse={() => setRosterCollapsed(c => !c)}
       />
 
-      <Map />
+      <Map filterType={filterType} activeTripId={activeTripId} />
     </div>
   );
 }

--- a/src/utils/geocodeAddress.ts
+++ b/src/utils/geocodeAddress.ts
@@ -24,10 +24,8 @@ export async function geocodeAddress(address: string): Promise<Coordinates> {
   }
 
   const key =
-    (typeof process !== 'undefined' && process.env.OPENCAGE_API_KEY) ||
-    (typeof import.meta !== 'undefined'
-      ? (import.meta as any).env?.VITE_OPENCAGE_API_KEY
-      : undefined) ||
+    (typeof process !== 'undefined' &&
+      (process.env.OPENCAGE_API_KEY || process.env.VITE_OPENCAGE_API_KEY)) ||
     'YOUR_OPENCAGE_API_KEY';
   try {
     const opencage = await fetch(


### PR DESCRIPTION
## Summary
- support filtering map markers when trip manifest is filtered
- remove `import.meta` usage in `geocodeAddress`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546a227fc4832fa5059a84b0134c70