### PR TITLE
Optimize map icon rendering

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -4,9 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../store';
 import { setZoom, setCenter, setDarkMode } from '../store/mapUiSlice';
-import { useFitMapToEntities, useProjectedTrips } from '../hooks';
-import DriverIcon from './DriverIcon';
-import TripPin from './TripPin';
+import { useFitMapToEntities } from '../hooks';
 import './MapStyles.css';
 
 type FilterType = 'none' | 'trip' | 'driver' | 'passenger';
@@ -41,8 +39,8 @@ export default function Map({ filterType, activeTripId }: Props) {
 
   useFitMapToEntities(mapRef.current, visibleDrivers, visibleTrips);
 
-  const [driverPos, setDriverPos] = useState<Record<string, { x: number; y: number }>>({});
-  const tripPos = useProjectedTrips(mapRef.current, visibleTrips);
+  const driverMarkersRef = useRef<Record<string, maplibregl.Marker>>({});
+  const tripMarkersRef = useRef<Record<string, { pickup: maplibregl.Marker; dropoff: maplibregl.Marker }>>({});
 
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
@@ -65,14 +63,17 @@ export default function Map({ filterType, activeTripId }: Props) {
       });
       mapRef.current.addControl(new maplibregl.NavigationControl());
       mapRef.current.on('move', () => {
+        // markers automatically reposition
+      });
+      mapRef.current.on('moveend', () => {
         if (!mapRef.current) return;
         const c = mapRef.current.getCenter();
         dispatch(setCenter([c.lng, c.lat]));
-        dispatch(setZoom(mapRef.current.getZoom()));
-        updatePositions();
       });
-      mapRef.current.on('zoom', updatePositions);
-      mapRef.current.on('resize', updatePositions);
+      mapRef.current.on('zoomend', () => {
+        if (!mapRef.current) return;
+        dispatch(setZoom(mapRef.current.getZoom()));
+      });
       setMapReady(true);
     } else {
       mapRef.current.setStyle(
@@ -83,43 +84,90 @@ export default function Map({ filterType, activeTripId }: Props) {
       mapRef.current.setZoom(ui.zoom);
       mapRef.current.setCenter(ui.center);
     }
-    updatePositions();
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return () => {
       if (mapRef.current) {
         mapRef.current.remove();
         mapRef.current = null;
       }
+      Object.values(driverMarkersRef.current).forEach(m => m.remove());
+      driverMarkersRef.current = {};
+      Object.values(tripMarkersRef.current).forEach(p => {
+        p.pickup.remove();
+        p.dropoff.remove();
+      });
+      tripMarkersRef.current = {};
       setMapReady(false);
     };
   }, [ui.isDarkMode]);
 
-  const updatePositions = () => {
-    if (!mapRef.current) return;
-    const m = mapRef.current;
-    const dPos: Record<string, { x: number; y: number }> = {};
-    visibleDrivers.forEach(d => {
-      const p = m.project([d.lng, d.lat]);
-      dPos[d.id] = { x: p.x, y: p.y };
-    });
-    setDriverPos(dPos);
-  };
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
 
-  useEffect(updatePositions, [visibleDrivers]);
+    const existing = new Set(Object.keys(driverMarkersRef.current));
+    visibleDrivers.forEach(d => {
+      let marker = driverMarkersRef.current[d.id];
+      if (!marker) {
+        const el = document.createElement('div');
+        el.className = 'map-driver';
+        const body = document.createElement('div');
+        body.className = 'icon-body';
+        el.appendChild(body);
+        marker = new maplibregl.Marker({ element: el })
+          .setLngLat([d.lng, d.lat])
+          .addTo(map);
+        driverMarkersRef.current[d.id] = marker;
+      } else {
+        marker.setLngLat([d.lng, d.lat]);
+      }
+      existing.delete(d.id);
+    });
+    existing.forEach(id => {
+      driverMarkersRef.current[id].remove();
+      delete driverMarkersRef.current[id];
+    });
+  }, [mapReady, visibleDrivers]);
+
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return;
+    const map = mapRef.current;
+
+    const existing = new Set(Object.keys(tripMarkersRef.current));
+    visibleTrips.forEach(t => {
+      let pair = tripMarkersRef.current[t.id];
+      if (!pair) {
+        const pEl = document.createElement('div');
+        pEl.className = 'map-pin map-pickup-pin';
+        pEl.textContent = 'P';
+        const dEl = document.createElement('div');
+        dEl.className = 'map-pin map-dropoff-pin';
+        dEl.textContent = 'D';
+        pair = {
+          pickup: new maplibregl.Marker({ element: pEl })
+            .setLngLat([t.pickup.lng, t.pickup.lat])
+            .addTo(map),
+          dropoff: new maplibregl.Marker({ element: dEl })
+            .setLngLat([t.dropoff.lng, t.dropoff.lat])
+            .addTo(map),
+        };
+        tripMarkersRef.current[t.id] = pair;
+      } else {
+        pair.pickup.setLngLat([t.pickup.lng, t.pickup.lat]);
+        pair.dropoff.setLngLat([t.dropoff.lng, t.dropoff.lat]);
+      }
+      existing.delete(t.id);
+    });
+    existing.forEach(id => {
+      tripMarkersRef.current[id].pickup.remove();
+      tripMarkersRef.current[id].dropoff.remove();
+      delete tripMarkersRef.current[id];
+    });
+  }, [mapReady, visibleTrips]);
 
   return (
     <div className="map-container">
       <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
-      {visibleDrivers.map(d =>
-        driverPos[d.id] ? (
-          <DriverIcon key={d.id} driver={d} position={driverPos[d.id]} />
-        ) : null
-      )}
-      {visibleTrips.map(t =>
-        tripPos[t.id] ? (
-          <TripPin key={t.id} trip={t} position={tripPos[t.id]} />
-        ) : null
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- handle map movement events only on `moveend` and `zoomend`
- use MapLibre markers for drivers and trips
- clean up markers when the map unmounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546ce188dc832fa78707d61e3885e3