### PR TITLE
Improve map filtering and add passenger filter test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ export default function App() {
         onToggleCollapse={() => setRosterCollapsed(c => !c)}
       />
 
-      <Map filterType={filterType} activeTripId={activeTripId} />
+      <Map filterType={filterType} activeTripId={activeTripId} filterId={filterId} />
     </div>
   );
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -12,8 +12,9 @@ type FilterType = 'none' | 'trip' | 'driver' | 'passenger';
 interface Props {
   filterType: FilterType;
   activeTripId: string | null;
+  filterId: string | null;
 }
-export default function Map({ filterType, activeTripId }: Props) {
+export default function Map({ filterType, activeTripId, filterId }: Props) {
   const dispatch = useDispatch();
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<LibMap | null>(null);
@@ -25,8 +26,16 @@ export default function Map({ filterType, activeTripId }: Props) {
 
   let visibleDrivers = drivers;
   let visibleTrips = trips;
-  if (filterType !== 'none') {
-    const active = trips.find(t => t.id === activeTripId);
+
+  if (filterType === 'passenger') {
+    visibleTrips = trips.filter(t => t.passengerName === filterId);
+    const driverIds = new Set(visibleTrips.map(t => t.driverId));
+    visibleDrivers = drivers.filter(d => driverIds.has(d.id));
+  } else if (filterType === 'driver') {
+    visibleTrips = trips.filter(t => t.driverId === filterId);
+    visibleDrivers = drivers.filter(d => d.id === filterId);
+  } else if (filterType === 'trip') {
+    const active = trips.find(t => t.id === (activeTripId || filterId));
     if (active) {
       visibleTrips = [active];
       const driver = drivers.find(d => d.id === active.driverId);

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import store from '../../store';
+import { setDrivers } from '../../store/driversSlice';
+import { setTrips } from '../../store/tripsSlice';
+import { setDarkMode } from '../../store/mapUiSlice';
+import Map from '../Map';
+
+jest.mock('maplibre-gl/dist/maplibre-gl.css', () => ({}));
+jest.mock('../MapStyles.css', () => ({}));
+
+jest.mock('maplibre-gl', () => {
+  class Marker {
+    element: HTMLElement;
+    constructor({ element }: { element: HTMLElement }) {
+      this.element = element;
+    }
+    setLngLat() { return this; }
+    addTo(map: any) { map._element.appendChild(this.element); return this; }
+    remove() { if (this.element.parentNode) this.element.parentNode.removeChild(this.element); }
+  }
+  return {
+    Map: class {
+      _element: HTMLElement;
+      constructor(opts: any) { this._element = opts.container; }
+      addControl() {}
+      on() {}
+      remove() {}
+      setStyle() {}
+      setZoom() {}
+      setCenter() {}
+      getCenter() { return { lng: 0, lat: 0 }; }
+      getZoom() { return 12; }
+      fitBounds() {}
+    },
+    LngLatBounds: class {
+      sw: [number, number];
+      ne: [number, number];
+      constructor(sw: [number, number], ne: [number, number]) {
+        this.sw = sw; this.ne = ne;
+      }
+      extend(pt: [number, number]) {
+        return this;
+      }
+    },
+    NavigationControl: class {},
+    Marker,
+  };
+});
+
+describe('Map passenger filter', () => {
+  test('shows markers for all trips of the passenger', async () => {
+    const originalDrivers = store.getState().drivers;
+    const originalTrips = store.getState().trips;
+    const originalUi = store.getState().mapUi;
+
+    store.dispatch(setDrivers([
+      { id: 'd1', lat: 0, lng: 0, status: 'idle' },
+      { id: 'd2', lat: 2, lng: 2, status: 'idle' },
+    ]));
+    store.dispatch(setTrips([
+      { id: 't1', driverId: 'd1', status: 'pending', passengerName: 'Alice', pickup: { lat: 0, lng: 0 }, dropoff: { lat: 1, lng: 1 } },
+      { id: 't2', driverId: 'd2', status: 'pending', passengerName: 'Alice', pickup: { lat: 2, lng: 2 }, dropoff: { lat: 3, lng: 3 } },
+      { id: 't3', driverId: 'd1', status: 'pending', passengerName: 'Bob', pickup: { lat: 4, lng: 4 }, dropoff: { lat: 5, lng: 5 } },
+    ]));
+    store.dispatch(setDarkMode(false));
+
+    const { container } = render(
+      <Provider store={store}>
+        <Map filterType="passenger" filterId="Alice" activeTripId={null} />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.map-pin.map-pickup-pin').length).toBe(2);
+      expect(container.querySelectorAll('.map-pin.map-dropoff-pin').length).toBe(2);
+    });
+
+    store.dispatch(setDrivers(originalDrivers));
+    store.dispatch(setTrips(originalTrips));
+    store.dispatch(setDarkMode(originalUi.isDarkMode));
+  });
+});

--- a/src/hooks/useProjectedTrips.ts
+++ b/src/hooks/useProjectedTrips.ts
@@ -23,7 +23,7 @@ export default function useProjectedTrips(
 ): ProjectedTripPositions {
   const [positions, setPositions] = useState<ProjectedTripPositions>({});
   const lastHashRef = useRef<string>('');
-  const timerRef = useRef<number>();
+  const timerRef = useRef<number | undefined>(undefined);
 
   const projectTrips = () => {
     if (!map) return;


### PR DESCRIPTION
## Summary
- add filterId prop to `Map`
- filter map markers by passenger, driver, or trip
- forward filterId from `App` to `Map`
- fix timerRef initialization
- test passenger filter shows all passenger trips on map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549cb06f34832f8307a4b762b8d0ff