### PR TITLE
Add user agent to nominatim requests

### DIFF
--- a/src/utils/geocodeAddress.ts
+++ b/src/utils/geocodeAddress.ts
@@ -22,7 +22,12 @@ export async function geocodeAddress(address: string): Promise<Coordinates> {
 
   try {
     const nominatim = await fetch(
-      `https://nominatim.openstreetmap.org/search?format=json&q=${encoded}`
+      `https://nominatim.openstreetmap.org/search?format=json&q=${encoded}`,
+      {
+        headers: {
+          "User-Agent": "DispatchSystem/1.0 (your-email@example.com)",
+        },
+      }
     );
     if (nominatim.ok) {
       const data: Array<{ lat: string; lon: string }> = await nominatim.json();


### PR DESCRIPTION
## Summary
- add custom `User-Agent` header to nominatim lookup

## Testing
- `npm test`
- `node` geocode request *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6854a8b8f1f8832fa42cabf23d5e6433