### PR TITLE
Wrap Map test cleanup in act

### DIFF
--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import store from '../../store';
 import { setDrivers } from '../../store/driversSlice';
@@ -78,8 +79,10 @@ describe('Map passenger filter', () => {
       expect(container.querySelectorAll('.map-pin.map-dropoff-pin').length).toBe(2);
     });
 
-    store.dispatch(setDrivers(originalDrivers));
-    store.dispatch(setTrips(originalTrips));
-    store.dispatch(setDarkMode(originalUi.isDarkMode));
+    act(() => {
+      store.dispatch(setDrivers(originalDrivers));
+      store.dispatch(setTrips(originalTrips));
+      store.dispatch(setDarkMode(originalUi.isDarkMode));
+    });
   });
 });


### PR DESCRIPTION
## Summary
- wrap Map cleanup dispatches in `act`
- import `act` from `react-dom/test-utils`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854af78b57c832f9e3883ae8785748c