### PR TITLE
Fix passenger map filtering

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,7 @@ export default {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true, tsconfig: './tsconfig.json' }],
+  },
 };

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -31,6 +31,13 @@ export default function Map({ filterType, activeTripId, filterId }: Props) {
     visibleTrips = trips.filter(t => t.passengerName === filterId);
     const driverIds = new Set(visibleTrips.map(t => t.driverId));
     visibleDrivers = drivers.filter(d => driverIds.has(d.id));
+
+    if (activeTripId) {
+      const active = visibleTrips.find(t => t.id === activeTripId);
+      if (active) {
+        visibleDrivers = visibleDrivers.filter(d => d.id === active.driverId);
+      }
+    }
   } else if (filterType === 'driver') {
     visibleTrips = trips.filter(t => t.driverId === filterId);
     visibleDrivers = drivers.filter(d => d.id === filterId);

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -85,4 +85,38 @@ describe('Map passenger filter', () => {
       store.dispatch(setDarkMode(originalUi.isDarkMode));
     });
   });
+
+  test('filters drivers by active trip id', async () => {
+    const originalDrivers = store.getState().drivers;
+    const originalTrips = store.getState().trips;
+    const originalUi = store.getState().mapUi;
+
+    store.dispatch(setDrivers([
+      { id: 'd1', lat: 0, lng: 0, status: 'idle' },
+      { id: 'd2', lat: 2, lng: 2, status: 'idle' },
+    ]));
+    store.dispatch(setTrips([
+      { id: 't1', driverId: 'd1', status: 'pending', passengerName: 'Alice', pickup: { lat: 0, lng: 0 }, dropoff: { lat: 1, lng: 1 } },
+      { id: 't2', driverId: 'd2', status: 'pending', passengerName: 'Alice', pickup: { lat: 2, lng: 2 }, dropoff: { lat: 3, lng: 3 } },
+    ]));
+    store.dispatch(setDarkMode(false));
+
+    const { container } = render(
+      <Provider store={store}>
+        <Map filterType="passenger" filterId="Alice" activeTripId="t1" />
+      </Provider>
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.map-driver').length).toBe(1);
+      expect(container.querySelectorAll('.map-pin.map-pickup-pin').length).toBe(2);
+      expect(container.querySelectorAll('.map-pin.map-dropoff-pin').length).toBe(2);
+    });
+
+    act(() => {
+      store.dispatch(setDrivers(originalDrivers));
+      store.dispatch(setTrips(originalTrips));
+      store.dispatch(setDarkMode(originalUi.isDarkMode));
+    });
+  });
 });

--- a/src/utils/geocodeAddress.ts
+++ b/src/utils/geocodeAddress.ts
@@ -19,7 +19,17 @@ export function clampToNY({ lat, lng }: Coordinates): Coordinates {
 
 export async function geocodeAddress(address: string): Promise<Coordinates> {
   const encoded = encodeURIComponent(address);
-  const email = import.meta.env.VITE_NOMINATIM_EMAIL || 'your-email@example.com';
+  const metaEnv = (() => {
+    try {
+      return (0, eval)('import.meta.env');
+    } catch {
+      return undefined;
+    }
+  })() as any;
+  const email =
+    (metaEnv && metaEnv.VITE_NOMINATIM_EMAIL) ||
+    process.env.VITE_NOMINATIM_EMAIL ||
+    'your-email@example.com';
 
   try {
     const nominatim = await fetch(
@@ -43,7 +53,10 @@ export async function geocodeAddress(address: string): Promise<Coordinates> {
     // ignore error and fall back
   }
 
-  const key = import.meta.env.VITE_OPENCAGE_API_KEY || 'YOUR_OPENCAGE_API_KEY'
+  const key =
+    (metaEnv && metaEnv.VITE_OPENCAGE_API_KEY) ||
+    process.env.VITE_OPENCAGE_API_KEY ||
+    'YOUR_OPENCAGE_API_KEY';
 
   try {
     const opencage = await fetch(


### PR DESCRIPTION
## Summary
- filter passenger map drivers by active trip
- update jest config to use ts-jest transform
- rely on import.meta.env with process.env fallback for geocode secrets
- test passenger map driver filtering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855b01b2aa8832f9b792075b9ed4cb1