### PR TITLE
Add passenger page components

### DIFF
--- a/src/components/PassengerInfoPanel.tsx
+++ b/src/components/PassengerInfoPanel.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import styles from './PassengerPage.module.css';
+
+export interface PassengerDetails {
+  phone?: string;
+  medicaidId?: string;
+  invoice?: string;
+  notes?: string;
+}
+
+interface PassengerInfoPanelProps {
+  details: PassengerDetails;
+}
+
+export default function PassengerInfoPanel({ details }: PassengerInfoPanelProps) {
+  return (
+    <div className={styles.passengerMainInfo} id="passenger-info-panel">
+      <p>
+        <i className="fas fa-phone" /> <span data-field="phone">{details.phone || 'N/A'}</span>
+      </p>
+      <p>
+        <i className="fas fa-id-card" /> <span data-field="medicaidId">{details.medicaidId || 'N/A'}</span>
+      </p>
+      <p>
+        <i className="fas fa-file-invoice" /> <span data-field="invoice">{details.invoice || 'N/A'}</span>
+      </p>
+      <p>
+        <i className="fas fa-sticky-note" /> <span data-field="notes">{details.notes || 'No notes.'}</span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/PassengerPage.module.css
+++ b/src/components/PassengerPage.module.css
@@ -1,0 +1,94 @@
+.passengerPageView {
+  animation: fade-in 0.4s;
+  padding: 10px;
+}
+
+.passengerMainInfo {
+  background-color: var(--bg-deep-charcoal);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 15px;
+}
+
+.passengerMainInfo p {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-bottom: 5px;
+}
+
+.passengerMainInfo p i {
+  width: 15px;
+  margin-right: 8px;
+  text-align: center;
+  color: var(--accent-teal);
+}
+
+.tripHistoryList h5 {
+  margin: 15px 5px 10px;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.tripHistoryItem {
+  background: var(--bg-deep-charcoal);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px;
+  margin-bottom: 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.historyItemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.historyItemHeader span:first-child {
+  color: var(--text-primary);
+}
+
+.tripHistoryItem:hover {
+  border-color: var(--accent-teal);
+}
+
+.tripHistoryItemActive {
+  border-color: var(--accent-teal);
+  background-color: var(--bg-slate-blue);
+}
+
+.tripHistoryItemMuted {
+  opacity: 0.6;
+}
+
+.tripHistoryItemMuted:hover {
+  opacity: 1;
+}
+
+.panelHeaderBtn {
+  background: none;
+  border: 1px solid var(--text-secondary);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.panelHeaderBtn:hover {
+  background-color: var(--accent-teal);
+  color: var(--bg-deep-charcoal);
+  border-color: var(--accent-teal);
+}
+
+.panelHeaderBtn i {
+  margin-right: 5px;
+}

--- a/src/components/PassengerPage.tsx
+++ b/src/components/PassengerPage.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Trip, MOCK_SCHEDULE } from '../mockData';
+import PassengerInfoPanel, { PassengerDetails } from './PassengerInfoPanel';
+import TripHistoryList from './TripHistoryList';
+import styles from './PassengerPage.module.css';
+
+interface PassengerPageProps {
+  passenger: string;
+  onBack: () => void;
+}
+
+function flattenSchedule(schedule: Record<string, Trip[]>): Trip[] {
+  return Object.entries(schedule).flatMap(([date, trips]) =>
+    trips.map(t => ({ ...t, date }))
+  );
+}
+
+export default function PassengerPage({ passenger, onBack }: PassengerPageProps) {
+  const allTrips = useMemo(() => flattenSchedule(MOCK_SCHEDULE), []);
+  const passengerTrips = useMemo(
+    () =>
+      allTrips
+        .filter(t => t.passenger === passenger)
+        .sort(
+          (a, b) =>
+            new Date(b.date).getTime() - new Date(a.date).getTime() ||
+            b.time.localeCompare(a.time)
+        ),
+    [allTrips, passenger]
+  );
+
+  const [activeTripId, setActiveTripId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (passengerTrips.length > 0 && !activeTripId) {
+      setActiveTripId(passengerTrips[0].id);
+    }
+  }, [passengerTrips, activeTripId]);
+
+  if (passengerTrips.length === 0) {
+    return null;
+  }
+
+  const activeTrip = passengerTrips.find(t => t.id === activeTripId) || passengerTrips[0];
+
+  const details: PassengerDetails = {
+    phone: activeTrip.phone,
+    medicaidId: activeTrip.medicaidNumber,
+    invoice: activeTrip.invoiceNumber,
+    notes: activeTrip.notes,
+  };
+
+  return (
+    <div className={styles.passengerPageView}>
+      <div className="panel-header">
+        <h2>{passenger}</h2>
+        <button className={styles.panelHeaderBtn} onClick={onBack} id="back-to-manifest-btn">
+          <i className="fas fa-arrow-left" />Back to Manifest
+        </button>
+      </div>
+      <PassengerInfoPanel details={details} />
+      <TripHistoryList trips={passengerTrips} activeTripId={activeTripId} onSelectTrip={setActiveTripId} />
+    </div>
+  );
+}

--- a/src/components/StatusPill.tsx
+++ b/src/components/StatusPill.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { TripStatus } from '../mockData';
+import { getTripStatusInfo } from '../utils/tripStatusUtils';
+
+interface StatusPillProps {
+  status: TripStatus;
+}
+
+export default function StatusPill({ status }: StatusPillProps) {
+  const info = getTripStatusInfo(status);
+  return <span className={`status-pill ${info.className}`}>{info.text}</span>;
+}

--- a/src/components/TripHistoryItem.tsx
+++ b/src/components/TripHistoryItem.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Trip } from '../mockData';
+import { formatDateWithYear } from '../utils/dateUtils';
+import StatusPill from './StatusPill';
+import styles from './PassengerPage.module.css';
+
+interface TripHistoryItemProps {
+  trip: Trip;
+  isActive: boolean;
+  isPast: boolean;
+  onSelect: (id: string) => void;
+}
+
+export default function TripHistoryItem({ trip, isActive, isPast, onSelect }: TripHistoryItemProps) {
+  const itemClasses = [
+    styles.tripHistoryItem,
+    isActive ? styles.tripHistoryItemActive : '',
+    isPast ? styles.tripHistoryItemMuted : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={itemClasses} onClick={() => onSelect(trip.id)}>
+      <div className={styles.historyItemHeader}>
+        <span>{formatDateWithYear(new Date(trip.date))}</span>
+        <StatusPill status={trip.status} />
+      </div>
+      <div className="trip-route">
+        {trip.from} <i className="fas fa-arrow-right-long" /> {trip.to}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TripHistoryList.tsx
+++ b/src/components/TripHistoryList.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Trip } from '../mockData';
+import TripHistoryItem from './TripHistoryItem';
+import styles from './PassengerPage.module.css';
+
+interface TripHistoryListProps {
+  trips: Trip[];
+  activeTripId: string | null;
+  onSelectTrip: (id: string) => void;
+}
+
+export default function TripHistoryList({ trips, activeTripId, onSelectTrip }: TripHistoryListProps) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return (
+    <div className={styles.tripHistoryList}>
+      <h5>Trip History</h5>
+      {trips.map(trip => {
+        const isPast = new Date(trip.date) < today;
+        const isActive = trip.id === activeTripId;
+        return (
+          <TripHistoryItem
+            key={trip.id}
+            trip={trip}
+            isActive={isActive}
+            isPast={isPast}
+            onSelect={onSelectTrip}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as TripDetails } from './TripDetails';
 export { default as DriverRoster } from './DriverRoster';
 export { default as DriverCard } from './DriverCard';
 export { default as Map } from './Map';
+export { default as PassengerPage } from './PassengerPage';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -7,3 +7,11 @@ export function formatDateForDisplay(date: Date): string {
     ? 'Today'
     : date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
+
+export function formatDateWithYear(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}

--- a/src/utils/tripStatusUtils.ts
+++ b/src/utils/tripStatusUtils.ts
@@ -1,0 +1,35 @@
+import { TripStatus } from '../mockData';
+
+export interface TripStatusInfo {
+  className: string;
+  text: string;
+}
+
+export function getTripStatusInfo(status: TripStatus): TripStatusInfo {
+  switch (status) {
+    case 'en-route':
+      return { className: 'status-pill-progress', text: 'En-Route' };
+    case 'in-transit':
+      return { className: 'status-pill-progress', text: 'In-Transit' };
+    case 'at-pickup':
+      return { className: 'status-pill-arrived', text: 'At Pickup' };
+    case 'at-dropoff':
+      return { className: 'status-pill-arrived', text: 'At Dropoff' };
+    case 'complete':
+      return { className: 'status-pill-available', text: 'Complete' };
+    case 'pending':
+      return { className: 'status-pill-progress', text: 'Pending' };
+    case 'cancel':
+      return { className: 'status-pill-available', text: 'Cancel' };
+    case 'no_show':
+      return { className: 'status-pill-available', text: 'No Show' };
+    case 'waiting':
+      return { className: 'status-pill-progress', text: 'Waiting' };
+    case 're-assigned':
+      return { className: 'status-pill-progress', text: 'Re-assigned' };
+    case 'not-confirmed':
+      return { className: 'status-pill-progress', text: 'Not Confirmed' };
+    default:
+      return { className: 'status-pill-available', text: status };
+  }
+}


### PR DESCRIPTION
## Summary
- add modular React components for passenger page
- convert passenger page styles into a CSS module
- map trip statuses with helper util
- extend date utils with `formatDateWithYear`
- export new component from components index

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fc4efd58832fb989e7ecbf71a994