### PR TITLE
Add passenger page view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setDriverDetails } from './store/driverDetailsSlice';
 import { setTripsSchedule } from './store/tripsDetailsSlice';
@@ -13,6 +13,7 @@ import {
   TripQueue,
   DriverRoster,
   Map,
+  PassengerPage,
 } from './components';
 
 type FilterType = 'none' | 'trip' | 'driver' | 'passenger';
@@ -40,6 +41,7 @@ export default function App() {
   const [filterId, setFilterId] = useState<string | null>(null);
   const [detailedTrip, setDetailedTrip] = useState<Trip | null>(null);
   const [activeTripId, setActiveTripId] = useState<string | null>(null);
+  const [passengerView, setPassengerView] = useState<string | null>(null);
   const [rosterCollapsed, setRosterCollapsed] = useState(false);
 
   const dateKey = getDateKey(selectedDate);
@@ -56,6 +58,7 @@ export default function App() {
     setFilterId(null);
     setDetailedTrip(null);
     setActiveTripId(null);
+    setPassengerView(null);
   }, [selectedDate]);
 
   return (
@@ -71,26 +74,39 @@ export default function App() {
         onDateChange={setSelectedDate}
       />
 
-      <TripQueue
-        selectedDate={selectedDate}
-        filterType={filterType}
-        filterId={filterId}
-        detailedTrip={detailedTrip}
-        activeTripId={activeTripId}
-        onSelectTrip={setActiveTripId}
-        onPassengerFilter={passenger => {
-          setFilterType('passenger');
-          setFilterId(passenger);
-          setDetailedTrip(null);
-        }}
-        onShowTripDetails={setDetailedTrip}
-        onCloseTripDetails={() => setDetailedTrip(null)}
-        onClearFilter={() => {
-          setFilterType('none');
-          setFilterId(null);
-          setDetailedTrip(null);
-        }}
-      />
+      {passengerView ? (
+        <PassengerPage
+          passenger={passengerView}
+          onBack={() => {
+            setPassengerView(null);
+            setFilterType('none');
+            setFilterId(null);
+            setDetailedTrip(null);
+          }}
+        />
+      ) : (
+        <TripQueue
+          selectedDate={selectedDate}
+          filterType={filterType}
+          filterId={filterId}
+          detailedTrip={detailedTrip}
+          activeTripId={activeTripId}
+          onSelectTrip={setActiveTripId}
+          onPassengerFilter={passenger => {
+            setFilterType('passenger');
+            setFilterId(passenger);
+            setDetailedTrip(null);
+          }}
+          onShowPassengerPage={setPassengerView}
+          onShowTripDetails={setDetailedTrip}
+          onCloseTripDetails={() => setDetailedTrip(null)}
+          onClearFilter={() => {
+            setFilterType('none');
+            setFilterId(null);
+            setDetailedTrip(null);
+          }}
+        />
+      )}
 
       <DriverRoster
         selectedDate={selectedDate}

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import store from '../store';
+import App from '../App';
+import * as tripUtils from '../utils/tripUtils';
+import { setTrips } from '../store/tripsSlice';
+import { MOCK_TRIPS_MAP } from '../mockData';
+
+jest.mock('../components/Map', () => () => <div data-testid="map" />);
+
+describe('App passenger interactions', () => {
+  const originalTrips = store.getState().trips;
+
+  beforeEach(() => {
+    jest.spyOn(tripUtils, 'mapScheduleToTrips').mockResolvedValue(MOCK_TRIPS_MAP);
+  });
+
+  afterEach(() => {
+    store.dispatch(setTrips(originalTrips));
+    (tripUtils.mapScheduleToTrips as jest.Mock).mockRestore();
+  });
+
+  test('opens passenger page on trip card double click', async () => {
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    );
+
+    const card = (await screen.findAllByText('Dr. Evelyn Reed'))[0].closest('.trip-card')!;
+    fireEvent.doubleClick(card);
+
+    expect(await screen.findByText('Trip History')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Back to Manifest/i })).toBeInTheDocument();
+  });
+
+  test('filters trips when passenger name clicked', async () => {
+    render(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    );
+
+    const header = (await screen.findAllByText('Dr. Evelyn Reed'))[0];
+    fireEvent.click(header);
+
+    const title = await screen.findByText('Passenger: Dr. Evelyn Reed');
+    expect(title).toBeInTheDocument();
+  });
+});

--- a/src/components/TripCard.tsx
+++ b/src/components/TripCard.tsx
@@ -19,6 +19,7 @@ interface TripCardProps {
   isActive: boolean;
   onSelect: () => void;
   onPassengerFilter: () => void;
+  onShowPassengerPage: () => void;
   onShowDetails: () => void;
 }
 
@@ -27,6 +28,7 @@ export default function TripCard({
   isActive,
   onSelect,
   onPassengerFilter,
+  onShowPassengerPage,
   onShowDetails,
 }: TripCardProps) {
   return (
@@ -34,7 +36,7 @@ export default function TripCard({
       className={`trip-card ${isActive ? 'active' : ''}`}
       data-status={trip.status}
       onClick={onSelect}
-      onDoubleClick={onPassengerFilter}
+      onDoubleClick={onShowPassengerPage}
     >
       <div className="trip-header">
         <h3

--- a/src/components/TripQueue.tsx
+++ b/src/components/TripQueue.tsx
@@ -16,6 +16,7 @@ interface TripQueueProps {
   activeTripId: string | null;
   onSelectTrip: (tripId: string) => void;
   onPassengerFilter: (passenger: string) => void;
+  onShowPassengerPage: (passenger: string) => void;
   onShowTripDetails: (trip: Trip) => void;
   onCloseTripDetails: () => void;
   onClearFilter: () => void;
@@ -29,6 +30,7 @@ export default function TripQueue({
   activeTripId,
   onSelectTrip,
   onPassengerFilter,
+  onShowPassengerPage,
   onShowTripDetails,
   onCloseTripDetails,
   onClearFilter,
@@ -86,6 +88,7 @@ export default function TripQueue({
               isActive={activeTripId === trip.id}
               onSelect={() => onSelectTrip(trip.id)}
               onPassengerFilter={() => onPassengerFilter(trip.passenger)}
+              onShowPassengerPage={() => onShowPassengerPage(trip.passenger)}
               onShowDetails={() => onShowTripDetails(trip)}
             />
           ))}

--- a/src/components/__tests__/TripCard.test.tsx
+++ b/src/components/__tests__/TripCard.test.tsx
@@ -32,6 +32,7 @@ test('calls onSelect when card is clicked', () => {
       isActive={false}
       onSelect={onSelect}
       onPassengerFilter={() => {}}
+      onShowPassengerPage={() => {}}
       onShowDetails={() => {}}
     />
   );
@@ -68,6 +69,7 @@ test('does not show pickup time when card is inactive', () => {
       isActive={false}
       onSelect={() => {}}
       onPassengerFilter={() => {}}
+      onShowPassengerPage={() => {}}
       onShowDetails={() => {}}
     />
   );
@@ -102,6 +104,7 @@ test('shows pickup time when card is active', () => {
       isActive={true}
       onSelect={() => {}}
       onPassengerFilter={() => {}}
+      onShowPassengerPage={() => {}}
       onShowDetails={() => {}}
     />
   );
@@ -136,6 +139,7 @@ test('shows transport icon when card is active', () => {
       isActive={true}
       onSelect={() => {}}
       onPassengerFilter={() => {}}
+      onShowPassengerPage={() => {}}
       onShowDetails={() => {}}
     />
   );

--- a/src/components/__tests__/TripQueue.test.tsx
+++ b/src/components/__tests__/TripQueue.test.tsx
@@ -16,6 +16,7 @@ test('shows message when no trips are available', () => {
         activeTripId={null}
         onSelectTrip={() => {}}
         onPassengerFilter={() => {}}
+        onShowPassengerPage={() => {}}
         onShowTripDetails={() => {}}
         onCloseTripDetails={() => {}}
         onClearFilter={() => {}}


### PR DESCRIPTION
## Summary
- show passenger page on card double click
- filter by passenger when header is clicked
- update tests for new passenger interactions

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855ffa93698832fb88f9f984909cb75